### PR TITLE
Prevent pixel data over-read in doWidthHeightOptim

### DIFF
--- a/cgif.c
+++ b/cgif.c
@@ -132,7 +132,7 @@ static uint32_t lzw_generate(Frame* pFrame, LZWGenState* pContext) {
   resetDict(pContext, pFrame->initDictLen);                                            // reset dictionary and issue clear-code at first
   while(strPos < pContext->numPixel) {                                                 // while there are still image data to be encoded
     parentIndex  = pContext->pImageData[strPos];                                       // start at root node
-    strPos       = lzw_crawl_tree(pContext, strPos, parentIndex, pFrame->initDictLen); // get longest sequence that is still in dictionary, return new position in image data
+    strPos       = lzw_crawl_tree(pContext, strPos, (uint16_t)parentIndex, pFrame->initDictLen); // get longest sequence that is still in dictionary, return new position in image data
   }
   pContext->pLZWData[pContext->LZWPos] = pFrame->initDictLen + 1;                      // termination code
   return pContext->LZWPos + 1;                                                         // return number of elements of LZW data
@@ -154,7 +154,7 @@ static uint32_t create_byte_list(Frame* pFrame, uint8_t *byteList, uint32_t lzwP
   // We keep the option to NOT output the clear code as the first symbol in this function.
   dictPos     = 1;
   for(i = 0; i < lzwPos; ++i) {                                                 // loop over all LZW codes
-    if((lzwCodeLen < MAX_CODE_LEN) && (n - (pFrame->initDictLen) == dictPos)) { // larger code is used for the 1st time at i = 256 ...+ 512 ...+ 1024 -> 256, 768, 1792
+    if((lzwCodeLen < MAX_CODE_LEN) && ((uint32_t)(n - (pFrame->initDictLen)) == dictPos)) { // larger code is used for the 1st time at i = 256 ...+ 512 ...+ 1024 -> 256, 768, 1792
       ++lzwCodeLen;                                                             // increment the length of the LZW codes (bit units)
       n *= 2;                                                                   // set threshold for next increment of LZW code size
     }
@@ -384,7 +384,7 @@ static uint8_t* doWidthHeightOptim(uint8_t* pFrameHeader, uint8_t const* pCurIma
 
   // find top 
   i = 0;
-  while(i != height && memcmp(pCurImageData + i * width, pBefImageData + i * width, width) == 0) {
+  while(i < (height - 1) && memcmp(pCurImageData + i * width, pBefImageData + i * width, width) == 0) {
   ++i;
   }
   top                     = i;
@@ -430,7 +430,7 @@ static uint8_t* doWidthHeightOptim(uint8_t* pFrameHeader, uint8_t const* pCurIma
   IMAGE_WIDTH(pFrameHeader) = (x + 1) - IMAGE_LEFT(pFrameHeader);
 
   // check whether we need a dummy pixel (frame is identical with one before)
-  if (IMAGE_HEIGHT(pFrameHeader) == 0) {
+  if (IMAGE_WIDTH(pFrameHeader) == 0 || IMAGE_HEIGHT(pFrameHeader) == 0) {
     IMAGE_WIDTH(pFrameHeader)  = 1;
     IMAGE_HEIGHT(pFrameHeader) = 1;
     IMAGE_LEFT(pFrameHeader)   = 0;

--- a/tests/max_color_table_test.c
+++ b/tests/max_color_table_test.c
@@ -18,7 +18,9 @@ int main(void) {
   //
   // create an image
   aPalette   = malloc(256 * 3);
+  memset(aPalette, 0, 256 * 3);
   pImageData = malloc(WIDTH * HEIGHT);   // actual image data
+  memset(pImageData, 0, WIDTH * HEIGHT);
   //
   // create new GIF
   memset(&gConfig, 0, sizeof(GIFConfig));
@@ -34,6 +36,7 @@ int main(void) {
   fConfig.pImageData = pImageData;
   cgif_addframe(pGIF, &fConfig);
   free(pImageData);  
+  free(aPalette);
   //
   // free allocated space at the end of the session
   cgif_close(pGIF);  

--- a/tests/performtests.sh
+++ b/tests/performtests.sh
@@ -24,7 +24,7 @@ do
   r=$(($r + $?))
   #
   # Check GIF with gifsicle
-  gifsicle -i out.gif -o /dev/null &> /dev/null
+  gifsicle --info out.gif -o /dev/null 2> /dev/null
   r=$(($r + $?))
   rm -f out.gif
   rm -f a.out


### PR DESCRIPTION
Hello, this PR provides a possible fix for a buffer over-read in `doWidthHeightOptim`.

```
==28543== Invalid read of size 1
==28543==    at 0x484C161: doWidthHeightOptim (cgif.c:403)
==28543==    by 0x484C5F5: cgif_addframe (cgif.c:510)
==28543==    by 0x109304: main (overlap_everything.c:44)
==28543==  Address 0x4a610a0 is 0 bytes after a block of size 10,000 alloc'd
==28543==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==28543==    by 0x1092AF: main (overlap_everything.c:38)
==28543== 
==28543== Invalid read of size 1
==28543==    at 0x484C17F: doWidthHeightOptim (cgif.c:403)
==28543==    by 0x484C5F5: cgif_addframe (cgif.c:510)
==28543==    by 0x109304: main (overlap_everything.c:44)
==28543==  Address 0x4a637f0 is 0 bytes after a block of size 10,000 alloc'd
==28543==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==28543==    by 0x484C583: cgif_addframe (cgif.c:505)
==28543==    by 0x1092F1: main (overlap_everything.c:43)
==28543== 
==28543== Invalid read of size 1
==28543==    at 0x484C218: doWidthHeightOptim (cgif.c:419)
==28543==    by 0x484C5F5: cgif_addframe (cgif.c:510)
==28543==    by 0x109304: main (overlap_everything.c:44)
==28543==  Address 0x4a63853 is 35 bytes inside a block of size 40 free'd
==28543==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==28543==    by 0x484BB81: LZW_GenerateStream (cgif.c:245)
==28543==    by 0x484C83F: cgif_addframe (cgif.c:538)
==28543==    by 0x1092F1: main (overlap_everything.c:43)
==28543==  Block was alloc'd at
==28543==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==28543==    by 0x484BA2F: LZW_GenerateStream (cgif.c:223)
==28543==    by 0x484C83F: cgif_addframe (cgif.c:538)
==28543==    by 0x1092F1: main (overlap_everything.c:43)
```

It also addresses a few other small things I found whilst investigating #1

- Prevent compiler warnings when casting sized integers
- Ensure tests use `gifsicle --info` flag (`-i` is `--interlace`)
- Ensure `max_color_table_test` zeroes/frees palette memory

