### PR TITLE
Add meson build configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macos-10.15
+          - windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Dependencies (ubuntu)
+        if: contains(matrix.os, 'ubuntu')
+        run: sudo apt install gifsicle valgrind
+      - name: Dependencies (macos)
+        if: contains(matrix.os, 'macos')
+        run: brew install gifsicle
+      - name: Dependencies (windows)
+        if: contains(matrix.os, 'windows')
+        run: choco install gifsicle
+      - name: Build and test
+        uses: BSFishy/meson-build@v1.0.3
+        with:
+          action: test
+          meson-version: "0.59.0"
+          ninja-version: "1.10.0.post3"
+      - name: Verify test output
+        run: for f in build/*.gif; do gifsicle --info $f || exit 1; done
+        shell: bash
+      - name: Valgrind
+        if: contains(matrix.os, 'ubuntu')
+        uses: BSFishy/meson-build@v1.0.3
+        with:
+          action: test
+          options: "--wrap valgrind"
+          meson-version: "0.59.0"
+          ninja-version: "1.10.0.post3"
+        env:
+          VALGRIND_OPTS: "--memcheck:leak-check=full --memcheck:show-leak-kinds=definite --memcheck:error-exitcode=1"
+      - name: Valgrind output
+        if: contains(matrix.os, 'ubuntu')
+        run: cat build/meson-logs/testlog-valgrind.txt

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,25 @@
+project(
+  'libcgif',
+  'c',
+  license : 'MIT',
+  default_options : ['c_std=c99'],
+)
+
+lib = library(
+  'cgif',
+  'cgif.c',
+  install : true,
+)
+
+install_headers('cgif.h')
+
+import('pkgconfig').generate(
+  lib,
+  name : 'cgif',
+  description : 'A fast and lightweight GIF encoder',
+)
+
+if get_option('tests') and not meson.is_cross_build()
+  libcgif_dep = declare_dependency(link_with : lib)
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+  'tests',
+  type : 'boolean',
+  value : true,
+  description : 'build tests',
+)

--- a/tests/all_optim.c
+++ b/tests/all_optim.c
@@ -15,7 +15,7 @@ static void initGIFConfig(GIFConfig* pConfig, uint8_t* pGlobalPalette, uint16_t 
   pConfig->height                  = height;
   pConfig->pGlobalPalette          = pGlobalPalette;
   pConfig->numGlobalPaletteEntries = numColors;
-  pConfig->path                   = "out.gif";
+  pConfig->path                   = "all_optim.gif";
 }
 
 static void initFrameConfig(FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay, uint32_t genFlags) {

--- a/tests/animated_stripe_pattern.c
+++ b/tests/animated_stripe_pattern.c
@@ -30,7 +30,7 @@ int main(void) {
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
-  gConfig.path                    = "out.gif";
+  gConfig.path                    = "animated_stripe_pattern.gif";
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);

--- a/tests/global_plus_local_table.c
+++ b/tests/global_plus_local_table.c
@@ -35,7 +35,7 @@ int main(void) {
   gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED;
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
-  gConfig.path                    = "out.gif";
+  gConfig.path                    = "global_plus_local_table.gif";
   pGIF = cgif_newgif(&gConfig);
   //
   // Add frame to GIF

--- a/tests/max_color_table_test.c
+++ b/tests/max_color_table_test.c
@@ -28,7 +28,7 @@ int main(void) {
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
-  gConfig.path                    = "out.gif";
+  gConfig.path                    = "max_color_table_test.gif";
   pGIF = cgif_newgif(&gConfig);  
   //
   // add frames to GIF

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,20 @@
+tests = [
+  'all_optim',
+  'animated_stripe_pattern',
+  'global_plus_local_table',
+  'max_color_table_test',
+  'min_color_table_test',
+  'only_local_table',
+  'overlap_everything',
+  'overlap_some_rows',
+]
+
+foreach t : tests
+  test_exe = executable(
+    'test_' + t,
+    t + '.c',
+    dependencies : [libcgif_dep],
+    include_directories : ['..'],
+  )
+  test(t, test_exe)
+endforeach

--- a/tests/min_color_table_test.c
+++ b/tests/min_color_table_test.c
@@ -26,7 +26,7 @@ int main(void) {
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
-  gConfig.path                    = "out.gif";
+  gConfig.path                    = "min_color_table_test.gif";
   pGIF = cgif_newgif(&gConfig);  
   //
   // add frames to GIF

--- a/tests/only_local_table.c
+++ b/tests/only_local_table.c
@@ -27,7 +27,7 @@ int main(void) {
   gConfig.attrFlags               = GIF_ATTR_NO_GLOBAL_TABLE;
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
-  gConfig.path                    = "out.gif";
+  gConfig.path                    = "only_local_table.gif";
   pGIF = cgif_newgif(&gConfig);
   //
   // Add frame to GIF

--- a/tests/overlap_everything.c
+++ b/tests/overlap_everything.c
@@ -30,7 +30,7 @@ int main(void) {
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
-  gConfig.path                    = "out.gif";
+  gConfig.path                    = "overlap_everything.gif";
   pGIF = cgif_newgif(&gConfig);
   //
   // Add frames to GIF

--- a/tests/overlap_some_rows.c
+++ b/tests/overlap_some_rows.c
@@ -30,7 +30,7 @@ int main(void) {
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
-  gConfig.path                    = "out.gif";
+  gConfig.path                    = "overlap_some_rows.gif";
   pGIF = cgif_newgif(&gConfig);
   //
   // Add frames to GIF

--- a/tests/performtests.sh
+++ b/tests/performtests.sh
@@ -15,19 +15,20 @@ tcc -c -o cgif.o -I.. ../cgif.c
 for sTest in $cfiles
 do
   printf %s "$sTest: "
-  tcc -o a.out -I.. $sTest cgif.o
-  idontcare=`./a.out`
+  basename=`basename $sTest .c`
+  tcc -o $basename.out -I.. $sTest cgif.o
+  idontcare=`./$basename.out`
   r=$?
   #
   # Check GIF with ImageMagick
-  identify out.gif > /dev/null 2> /dev/null
+  identify $basename.gif > /dev/null 2> /dev/null
   r=$(($r + $?))
   #
   # Check GIF with gifsicle
-  gifsicle --info out.gif -o /dev/null 2> /dev/null
+  gifsicle --info $basename.gif -o /dev/null 2> /dev/null
   r=$(($r + $?))
-  rm -f out.gif
-  rm -f a.out
+  rm -f $basename.gif
+  rm -f $basename.out
   rAll=$(($rAll + $r))
   if [ $r != 0 ]
   then


### PR DESCRIPTION
Hi, as discussed in #1 this PR adds a meson build script to allow all the major Linux distributions, macOS Homebrew etc. to start to build, package and distribute this library.

The tests have been updated so they write to their "own" file to allow these to be run in parallel.

It adds GitHub Actions CI configuration, including running the tests via valgrind.

https://github.com/lovell/cgif/actions/runs/1067901844
