### PR TITLE
Add support for colo(u)r table with first entry as transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ With our encoder you can create animated or static GIFs, you can or cannot use c
 GIF_ATTR_IS_ANIMATED          // make an animated GIF (default is non-animated GIF)
 GIF_ATTR_NO_GLOBAL_TABLE      // disable global color table (global color table is default)
 FRAME_ATTR_USE_LOCAL_TABLE    // use a local color table for a frame (not used by default)
+FRAME_ATTR_HAS_TRANSPARENCY   // first entry in color table contains transparency
 FRAME_GEN_USE_TRANSPARENCY    // use transparency optimization (size optimization)
 FRAME_GEN_USE_DIFF_WINDOW     // do encoding just for the sub-window that changed (size optimization)
 ```

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ With our encoder you can create animated or static GIFs, you can or cannot use c
 ```C
 GIF_ATTR_IS_ANIMATED          // make an animated GIF (default is non-animated GIF)
 GIF_ATTR_NO_GLOBAL_TABLE      // disable global color table (global color table is default)
+GIF_ATTR_HAS_TRANSPARENCY     // first entry in color table contains transparency
 FRAME_ATTR_USE_LOCAL_TABLE    // use a local color table for a frame (not used by default)
-FRAME_ATTR_HAS_TRANSPARENCY   // first entry in color table contains transparency
 FRAME_GEN_USE_TRANSPARENCY    // use transparency optimization (size optimization)
 FRAME_GEN_USE_DIFF_WINDOW     // do encoding just for the sub-window that changed (size optimization)
 ```

--- a/cgif.c
+++ b/cgif.c
@@ -464,13 +464,13 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
   imageHeight   = HEADER_HEIGHT(pGIF->aHeader);
 
   // determine fixed attributes of frame
-  isFirstFrame  = ((&pGIF->firstFrame == pGIF->pCurFrame))                ? 1 : 0;
-  useLocalTable = (pFrame->config.attrFlags & FRAME_ATTR_USE_LOCAL_TABLE) ? 1 : 0;
-  hasTransparency = (pConfig->attrFlags & FRAME_ATTR_HAS_TRANSPARENCY)    ? 1 : 0;
+  isFirstFrame    = ((&pGIF->firstFrame == pGIF->pCurFrame))                ? 1 : 0;
+  useLocalTable   = (pFrame->config.attrFlags & FRAME_ATTR_USE_LOCAL_TABLE) ? 1 : 0;
+  hasTransparency = (pConfig->attrFlags & FRAME_ATTR_HAS_TRANSPARENCY)      ? 1 : 0;
   // deactivate impossible size optimizations 
-  //  => in case the current frame or the frame before use a local-color table
+  //  => in case the current frame or the frame before use a local-color table or transparency
   // FRAME_GEN_USE_TRANSPARENCY and FRAME_GEN_USE_DIFF_WINDOW are not possible
-  if(isFirstFrame || useLocalTable || hasTransparency || (!isFirstFrame && (pFrame->pBef->config.attrFlags & FRAME_ATTR_USE_LOCAL_TABLE))) {
+  if(isFirstFrame || useLocalTable || hasTransparency || (!isFirstFrame && (pFrame->pBef->config.attrFlags & (FRAME_ATTR_USE_LOCAL_TABLE | FRAME_ATTR_HAS_TRANSPARENCY)))) {
     pFrame->config.genFlags &= ~(FRAME_GEN_USE_TRANSPARENCY | FRAME_GEN_USE_DIFF_WINDOW);
   }
 

--- a/cgif.c
+++ b/cgif.c
@@ -463,14 +463,14 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
   imageWidth    = HEADER_WIDTH(pGIF->aHeader);
   imageHeight   = HEADER_HEIGHT(pGIF->aHeader);
 
-  // determine fixed attributes of frame
+  // determine fixed attributes of frame / GIF
   isFirstFrame    = ((&pGIF->firstFrame == pGIF->pCurFrame))                ? 1 : 0;
   useLocalTable   = (pFrame->config.attrFlags & FRAME_ATTR_USE_LOCAL_TABLE) ? 1 : 0;
-  hasTransparency = (pConfig->attrFlags & FRAME_ATTR_HAS_TRANSPARENCY)      ? 1 : 0;
+  hasTransparency = (pGIF->config.attrFlags & GIF_ATTR_HAS_TRANSPARENCY)    ? 1 : 0;
   // deactivate impossible size optimizations 
   //  => in case the current frame or the frame before use a local-color table or transparency
   // FRAME_GEN_USE_TRANSPARENCY and FRAME_GEN_USE_DIFF_WINDOW are not possible
-  if(isFirstFrame || useLocalTable || hasTransparency || (!isFirstFrame && (pFrame->pBef->config.attrFlags & (FRAME_ATTR_USE_LOCAL_TABLE | FRAME_ATTR_HAS_TRANSPARENCY)))) {
+  if(isFirstFrame || useLocalTable || hasTransparency || (!isFirstFrame && (pFrame->pBef->config.attrFlags & FRAME_ATTR_USE_LOCAL_TABLE))) {
     pFrame->config.genFlags &= ~(FRAME_GEN_USE_TRANSPARENCY | FRAME_GEN_USE_DIFF_WINDOW);
   }
 
@@ -550,7 +550,7 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
   pFrame->pNext->pNext      = NULL;
   pGIF->pCurFrame           = pFrame->pNext;
 
-  // do things for animation, if necessary
+  // do things for animation / user-defined transparency, if necessary
   if(pGIF->config.attrFlags & GIF_ATTR_IS_ANIMATED) {
     memset(pFrame->aGraphicExt, 0, sizeof(pFrame->aGraphicExt));
     pFrame->aGraphicExt[0] = 0x21;

--- a/cgif.h
+++ b/cgif.h
@@ -8,6 +8,7 @@
 #define GIF_ATTR_IS_ANIMATED          (1uL << 1)       // make an animated GIF (default is non-animated GIF)
 #define GIF_ATTR_NO_GLOBAL_TABLE      (1uL << 2)       // disable global color table (global color table is default)
 #define FRAME_ATTR_USE_LOCAL_TABLE    (1uL << 0)       // use a local color table for a frame (local color table is not used by default)
+#define FRAME_ATTR_HAS_TRANSPARENCY   (1uL << 1)       // first entry in color table contains transparency
 // flags to decrease GIF-size
 #define FRAME_GEN_USE_TRANSPARENCY    (1uL << 0)       // use transparency optimization (setting pixels identical to previous frame transparent)
 #define FRAME_GEN_USE_DIFF_WINDOW     (1uL << 1)       // do encoding just for the sub-window that has changed from previous frame

--- a/cgif.h
+++ b/cgif.h
@@ -7,8 +7,8 @@
 // flags to set the GIF/frame-attributes
 #define GIF_ATTR_IS_ANIMATED          (1uL << 1)       // make an animated GIF (default is non-animated GIF)
 #define GIF_ATTR_NO_GLOBAL_TABLE      (1uL << 2)       // disable global color table (global color table is default)
+#define GIF_ATTR_HAS_TRANSPARENCY     (1uL << 3)       // first entry in color table contains transparency
 #define FRAME_ATTR_USE_LOCAL_TABLE    (1uL << 0)       // use a local color table for a frame (local color table is not used by default)
-#define FRAME_ATTR_HAS_TRANSPARENCY   (1uL << 1)       // first entry in color table contains transparency
 // flags to decrease GIF-size
 #define FRAME_GEN_USE_TRANSPARENCY    (1uL << 0)       // use transparency optimization (setting pixels identical to previous frame transparent)
 #define FRAME_GEN_USE_DIFF_WINDOW     (1uL << 1)       // do encoding just for the sub-window that has changed from previous frame

--- a/tests/has_transparency.c
+++ b/tests/has_transparency.c
@@ -19,7 +19,7 @@ int main(void) {
 
   memset(&gConfig, 0, sizeof(GIFConfig));
   memset(&fConfig, 0, sizeof(FrameConfig));
-  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED;
+  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED | GIF_ATTR_HAS_TRANSPARENCY;  // first entry in color table is transparency
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
@@ -32,7 +32,6 @@ int main(void) {
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);
   memset(pImageData, 0, WIDTH * HEIGHT);
-  fConfig.attrFlags  = FRAME_ATTR_HAS_TRANSPARENCY; // first entry in color table is transparency
   fConfig.pImageData = pImageData;
   fConfig.delay      = 100;
   // create an off/on pattern

--- a/tests/has_transparency.c
+++ b/tests/has_transparency.c
@@ -1,0 +1,53 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "cgif.h"
+
+#define WIDTH  99
+#define HEIGHT 99
+
+int main(void) {
+  GIF*          pGIF;
+  GIFConfig     gConfig;
+  FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = {
+    0x00, 0x00, 0x00, // black (transparent)
+    0xFF, 0xFF, 0xFF, // white
+  };
+
+  memset(&gConfig, 0, sizeof(GIFConfig));
+  memset(&fConfig, 0, sizeof(FrameConfig));
+  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED;
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 2;
+  gConfig.path                    = "has_transparency.gif";
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  memset(pImageData, 0, WIDTH * HEIGHT);
+  fConfig.attrFlags  = FRAME_ATTR_HAS_TRANSPARENCY; // first entry in color table is transparency
+  fConfig.pImageData = pImageData;
+  fConfig.delay      = 100;
+  // create an off/on pattern
+  for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
+    pImageData[i] = i % 2;
+  }
+  cgif_addframe(pGIF, &fConfig);
+  // create opposite pattern
+  for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
+    pImageData[i] = 1 - (i % 2);
+  }
+  cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  cgif_close(pGIF);
+  return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2,6 +2,7 @@ tests = [
   'all_optim',
   'animated_stripe_pattern',
   'global_plus_local_table',
+  'has_transparency',
   'max_color_table_test',
   'min_color_table_test',
   'only_local_table',


### PR DESCRIPTION
Guten Tag, I've taken the approach as suggested in #4, ensuring the relevant disposal method is set, plus added a unit test.

I've also tested this using a botched together libvips+cgif integration and the obligatory dancing banana.

![banana](https://user-images.githubusercontent.com/210965/127357016-fda9ff1f-7988-4789-8322-6e010532c13c.gif)
