### PR TITLE
Add support for a user-supplied write callback function

### DIFF
--- a/cgif.c
+++ b/cgif.c
@@ -584,7 +584,7 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
   if(pFrame->config.attrFlags & FRAME_ATTR_USE_LOCAL_TABLE) {
     write(pGIF, pFrame->aLocalColorTable, pFrame->initDictLen * 3);
   }
-  write(pGIF, (unsigned char*) &initialCodeSize, 1);
+  write(pGIF, &initialCodeSize, 1);
   write(pGIF, pFrame->pRasterData, pFrame->sizeRasterData);
 
   // free stuff

--- a/cgif.h
+++ b/cgif.h
@@ -19,6 +19,8 @@ typedef struct st_frame       Frame;                  // struct for a single fra
 typedef struct st_gifconfig    GIFConfig;               // global cofinguration parameters of the GIF
 typedef struct st_frameconfig  FrameConfig;             // local configuration parameters for a frame
 
+typedef int cgif_write_fn(void* pContext, const uint8_t* pData, const size_t numBytes); // callback function for stream-based output
+
 // prototypes
 GIF* cgif_newgif     (GIFConfig* pConfig);              // creates a new GIF (returns pointer to new GIF or NULL on error)
 int  cgif_addframe   (GIF* pGIF, FrameConfig* pConfig); // adds the next frame to an existing GIF (returns 0 on success)
@@ -28,13 +30,15 @@ int  cgif_close      (GIF* pGIF);                     // close file and free all
 // note: must stay AS IS for backward compatibility
 struct st_gifconfig {
   uint8_t*    pGlobalPalette;                            // global color table of the GIF
-  const char* path;                                      // path of the GIF to be created
+  const char* path;                                      // path of the GIF to be created, mutually exclusive with pWriteFn
   uint32_t    attrFlags;                                 // fixed attributes of the GIF (e.g. whether it is animated or not)
   uint32_t    genFlags;                                  // flags that determine how the GIF is generated (e.g. optimization)
   uint16_t    width;                                     // width of each frame in the GIF
   uint16_t    height;                                    // height of each frame in the GIF
   uint16_t    numGlobalPaletteEntries;                   // size of the global color table
   uint16_t    numLoops;                                  // number of repetitons of an animated GIF (set to INFINITE_LOOP for infinite loop)
+  cgif_write_fn *pWriteFn;                               // callback function for chunks of output data, mutually exclusive with path
+  void*       pContext;                                  // opaque pointer passed as the first parameter to pWriteFn
 };
 
 // FrameConfig type (parameters passed by user)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@ tests = [
   'only_local_table',
   'overlap_everything',
   'overlap_some_rows',
+  'write_fn',
 ]
 
 foreach t : tests

--- a/tests/write_fn.c
+++ b/tests/write_fn.c
@@ -1,0 +1,49 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "cgif.h"
+
+#define WIDTH  100
+#define HEIGHT 100
+
+static int pWriteFn(void* pContext, const uint8_t* pData, const size_t numBytes) {
+  return fwrite(pData, 1, numBytes, (FILE*) pContext);
+}
+
+int main(void) {
+  GIF*          pGIF;
+  GIFConfig     gConfig;
+  FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = {
+    0x00, 0x00, 0x00, // black
+    0xFF, 0xFF, 0xFF, // white
+  };
+
+  FILE* file = fopen("write_fn.gif", "wb");
+
+  memset(&gConfig, 0, sizeof(GIFConfig));
+  memset(&fConfig, 0, sizeof(FrameConfig));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 2;
+  gConfig.pWriteFn                = pWriteFn;
+  gConfig.pContext                = (void*) file;
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  memset(pImageData, 0, WIDTH * HEIGHT);
+  fConfig.pImageData = pImageData;
+  cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  cgif_close(pGIF);                  // free allocated space at the end of the session
+  fclose(file);
+  return 0;
+}


### PR DESCRIPTION
Here's a possible approach to allow stream-based output whilst remaining backwards-compatible, as discussed in #1