### PR TITLE
Rename public structs and defines to include the prefix CGIF (namespacing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,25 @@ To get an overview of the code, we recommend having a look at the header file ``
 
 ```C
 // These are the four struct types that contain all GIF data and parameters:
-typedef GIFConfig               // global cofinguration parameters of the GIF
-typedef FrameConfig             // local configuration parameters for a frame
-typedef GIF                     // struct for the full GIF
-typedef Frame                   // struct for a single frame
+typedef CGIF_Config               // global cofinguration parameters of the GIF
+typedef CGIF_FrameConfig          // local configuration parameters for a frame
+typedef CGIF                     // struct for the full GIF
+typedef CGIF_Frame               // struct for a single frame
 
 // The user needs only these three functions to create a GIF image:
-GIF* cgif_newgif    (GIFConfig* pConfig);               // creates a new GIF
-int  cgif_addframe  (GIF* pGIF, FrameConfig* pConfig);  // adds a frame to an existing GIF
-int  cgif_close     (GIF* pGIF);                        // close the created file and free memory
+CGIF* cgif_newgif   (CGIF_Config* pConfig);                   // creates a new GIF
+int  cgif_addframe  (CGIF* pGIF, CGIF_FrameConfig* pConfig);  // adds a frame to an existing GIF
+int  cgif_close     (CGIF* pGIF);                           // close the created file and free memory
 ```
 
-With our encoder you can create animated or static GIFs, you can or cannot use certain optimizations, and so on. You can switch between all these different options easily using the two attributes ```attrFlags``` and ```genFlags``` in the configurations ```GIFConfig``` and ```FrameConfig```. These attributes are of type ```uint32_t``` and bundle yes/no-options with a bit-wise logic. So far only a few of the 32 bits are used leaving space to include further functionalities ensuring backward compatibility. We provide the following flag settings which can be combined by bit-wise or-operations:
+With our encoder you can create animated or static GIFs, you can or cannot use certain optimizations, and so on. You can switch between all these different options easily using the two attributes ```attrFlags``` and ```genFlags``` in the configurations ```CGIF_Config``` and ```CGIF_FrameConfig```. These attributes are of type ```uint32_t``` and bundle yes/no-options with a bit-wise logic. So far only a few of the 32 bits are used leaving space to include further functionalities ensuring backward compatibility. We provide the following flag settings which can be combined by bit-wise or-operations:
 ```C
-GIF_ATTR_IS_ANIMATED          // make an animated GIF (default is non-animated GIF)
-GIF_ATTR_NO_GLOBAL_TABLE      // disable global color table (global color table is default)
-GIF_ATTR_HAS_TRANSPARENCY     // first entry in color table contains transparency
-FRAME_ATTR_USE_LOCAL_TABLE    // use a local color table for a frame (not used by default)
-FRAME_GEN_USE_TRANSPARENCY    // use transparency optimization (size optimization)
-FRAME_GEN_USE_DIFF_WINDOW     // do encoding just for the sub-window that changed (size optimization)
+CGIF_ATTR_IS_ANIMATED              // make an animated GIF (default is non-animated GIF)
+CGIF_ATTR_NO_GLOBAL_TABLE          // disable global color table (global color table is default)
+CGIF_ATTR_HAS_TRANSPARENCY         // first entry in color table contains transparency
+CGIF_FRAME_ATTR_USE_LOCAL_TABLE    // use a local color table for a frame (not used by default)
+CGIF_FRAME_GEN_USE_TRANSPARENCY    // use transparency optimization (size optimization)
+CGIF_FRAME_GEN_USE_DIFF_WINDOW     // do encoding just for the sub-window that changed (size optimization)
 ```
 If you didn't understand the point of ```attrFlags``` and ```genFlags``` and the flags, please don't worry. The example files ```cgif_example.c``` and ```cgif_example_video.c``` are all you need to get started and the used default settings for ```attrFlags``` and ```genFlags``` cover most cases quite well.
 

--- a/cgif.c
+++ b/cgif.c
@@ -479,7 +479,7 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
   hasTransparency = (pGIF->config.attrFlags & CGIF_ATTR_HAS_TRANSPARENCY)    ? 1 : 0;
   // deactivate impossible size optimizations 
   //  => in case the current frame or the frame before use a local-color table or transparency
-  // FRAME_GEN_USE_TRANSPARENCY and FRAME_GEN_USE_DIFF_WINDOW are not possible
+  // CGIF_FRAME_GEN_USE_TRANSPARENCY and CGIF_FRAME_GEN_USE_DIFF_WINDOW are not possible
   if(isFirstFrame || useLocalTable || hasTransparency || (pFrame->pBef->config.attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE)) {
     pFrame->config.genFlags &= ~(CGIF_FRAME_GEN_USE_TRANSPARENCY | CGIF_FRAME_GEN_USE_DIFF_WINDOW);
   }
@@ -513,11 +513,11 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
     pFrame->transIndex = pFrame->initDictLen - 1;
   }
 
-  // copy given raw image data into the new FrameConfig, as we might need it in a later stage.
+  // copy given raw image data into the new CGIF_FrameConfig, as we might need it in a later stage.
   pFrame->config.pImageData = malloc(imageWidth * imageHeight); // TBD check return value of malloc
   memcpy(pFrame->config.pImageData, pConfig->pImageData, imageWidth * imageHeight);
 
-  // purge overlap of current frame and frame before (wdith - height optim), if required (FRAME_GEN_USE_DIFF_WINDOW set)
+  // purge overlap of current frame and frame before (wdith - height optim), if required (CGIF_FRAME_GEN_USE_DIFF_WINDOW set)
   if(pFrame->config.genFlags & CGIF_FRAME_GEN_USE_DIFF_WINDOW) {
     pTmpImageData = doWidthHeightOptim(pFrame, pConfig->pImageData, pFrame->pBef->config.pImageData, imageWidth, imageHeight);
   } else {
@@ -532,7 +532,7 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
   IMAGE_TOP(pFrame->aImageHeader)    = hU16toLE(pFrame->top);
   IMAGE_LEFT(pFrame->aImageHeader)   = hU16toLE(pFrame->left);
 
-  // mark matching areas of the previous frame as transparent, if required (FRAME_GEN_USE_TRANSPARENCY set)
+  // mark matching areas of the previous frame as transparent, if required (CGIF_FRAME_GEN_USE_TRANSPARENCY set)
   if((pFrame->config.genFlags & CGIF_FRAME_GEN_USE_TRANSPARENCY) && pGIF->config.numGlobalPaletteEntries < 256) {
     if(pTmpImageData == NULL) {
       pTmpImageData = malloc(imageWidth * imageHeight); // TBD check return value of malloc

--- a/cgif.c
+++ b/cgif.c
@@ -124,7 +124,7 @@ static uint32_t lzw_crawl_tree(LZWGenState* pContext, uint32_t strPos, uint16_t 
 }
 
 /* generate LZW-codes that compress the image data*/
-static uint32_t lzw_generate(Frame* pFrame, LZWGenState* pContext) {
+static uint32_t lzw_generate(CGIF_Frame* pFrame, LZWGenState* pContext) {
   uint32_t strPos;
   uint8_t  parentIndex;
 
@@ -139,7 +139,7 @@ static uint32_t lzw_generate(Frame* pFrame, LZWGenState* pContext) {
 }
 
 /* pack the LZW data into a byte sequence*/
-static uint32_t create_byte_list(Frame* pFrame, uint8_t *byteList, uint32_t lzwPos, uint16_t *lzwStr){
+static uint32_t create_byte_list(CGIF_Frame* pFrame, uint8_t *byteList, uint32_t lzwPos, uint16_t *lzwStr){
   uint32_t i;
   uint32_t dictPos;                                                             // counting new LZW codes
   uint16_t n             = 2 * pFrame->initDictLen;                             // if n - pFrame->initDictLen == dictPos, the LZW code size is incremented by 1 bit
@@ -215,7 +215,7 @@ static uint32_t create_byte_list_block(uint8_t *byteList, uint8_t *byteListBlock
 }
 
 /* create all LZW raster data in GIF-format */
-static uint8_t* LZW_GenerateStream(Frame* pFrame, const uint32_t numPixel, const uint8_t* pImageData){
+static uint8_t* LZW_GenerateStream(CGIF_Frame* pFrame, const uint32_t numPixel, const uint8_t* pImageData){
   LZWGenState* pContext;
   uint32_t     lzwPos, bytePos;
   uint32_t     bytePosBlock;
@@ -248,7 +248,7 @@ static uint8_t* LZW_GenerateStream(Frame* pFrame, const uint32_t numPixel, const
 }
 
 /* initialize the header of the GIF */
-static void initMainHeader(GIF* pGIF) {
+static void initMainHeader(CGIF* pGIF) {
   uint16_t width, height;
   uint8_t  x;
   uint8_t  initCodeLen;
@@ -276,7 +276,7 @@ static void initMainHeader(GIF* pGIF) {
   HEADER_HEIGHT(pGIF->aHeader) = hU16toLE(height);
 
   // init packed field
-  x = (pGIF->config.attrFlags & GIF_ATTR_NO_GLOBAL_TABLE) ? 0 : 1;
+  x = (pGIF->config.attrFlags & CGIF_ATTR_NO_GLOBAL_TABLE) ? 0 : 1;
   pGIF->aHeader[HEADER_OFFSET_PACKED_FIELD] = (x << 7);                        // M = 1 (see GIF specs): Global color map is present
   if(x) {
     // calculate initial code length
@@ -287,7 +287,7 @@ static void initMainHeader(GIF* pGIF) {
 }
 
 /* initialize the global color table */
-static void initGlobalColorTable(GIF* pGIF) {
+static void initGlobalColorTable(CGIF* pGIF) {
   uint8_t*  pGlobalPalette;
   uint16_t  numGlobalPaletteEntries;
 
@@ -298,7 +298,7 @@ static void initGlobalColorTable(GIF* pGIF) {
 }
 
 /* initialize the local color table */
-static void initLocalColorTable(Frame* pFrame) {
+static void initLocalColorTable(CGIF_Frame* pFrame) {
   uint8_t* pLocalPalette;
   uint16_t numLocalPaletteEntries;
   
@@ -309,7 +309,7 @@ static void initLocalColorTable(Frame* pFrame) {
 }
 
 /* initialize NETSCAPE app extension block (needed for animation) */
-static void initAppExtBlock(GIF* pGIF) {
+static void initAppExtBlock(CGIF* pGIF) {
   memset(pGIF->aAppExt, 0, sizeof(pGIF->aAppExt));
 
   // set data
@@ -335,7 +335,7 @@ static void initAppExtBlock(GIF* pGIF) {
 }
 
 /* write a chunk of data to either a callback or a file */
-static int write(GIF* pGIF, const uint8_t* pData, const size_t numBytes) {
+static int write(CGIF* pGIF, const uint8_t* pData, const size_t numBytes) {
   if(pGIF->pFile) {
     return fwrite(pData, 1, numBytes, pGIF->pFile);
   } else if(pGIF->config.pWriteFn) {
@@ -345,15 +345,15 @@ static int write(GIF* pGIF, const uint8_t* pData, const size_t numBytes) {
 }
 
 /* create a new GIF */
-GIF* cgif_newgif(GIFConfig* pConfig) {
-  GIF*     pGIF;
+CGIF* cgif_newgif(CGIF_Config* pConfig) {
+  CGIF*     pGIF;
   uint8_t  initCodeSize;
 
-  pGIF = malloc(sizeof(GIF));
+  pGIF = malloc(sizeof(CGIF));
   if(pGIF == NULL) {
     return NULL; // error -> malloc failed
   }
-  memcpy(&(pGIF->config), pConfig, sizeof(GIFConfig));
+  memcpy(&(pGIF->config), pConfig, sizeof(CGIF_Config));
 
   // initiate all sections we can at this stage:
   // - main GIF header
@@ -362,14 +362,14 @@ GIF* cgif_newgif(GIFConfig* pConfig) {
   initMainHeader(pGIF);
 
   // global color table required? => init it.
-  if((pGIF->config.attrFlags & GIF_ATTR_NO_GLOBAL_TABLE) == 0) {
+  if((pGIF->config.attrFlags & CGIF_ATTR_NO_GLOBAL_TABLE) == 0) {
     initGlobalColorTable(pGIF);  
   }
   // GIF should be animated? => init corresponding app extension header (NETSCAPE2.0)
-  if(pConfig->attrFlags & GIF_ATTR_IS_ANIMATED) {
+  if(pConfig->attrFlags & CGIF_ATTR_IS_ANIMATED) {
     initAppExtBlock(pGIF);
   }
-  memset(&(pGIF->firstFrame), 0, sizeof(Frame));
+  memset(&(pGIF->firstFrame), 0, sizeof(CGIF_Frame));
   pGIF->pCurFrame = &(pGIF->firstFrame);
   
   // write first sections to file
@@ -378,18 +378,18 @@ GIF* cgif_newgif(GIFConfig* pConfig) {
     pGIF->pFile = fopen(pConfig->path, "wb"); // TBD check if fopen success
   }
   write(pGIF, pGIF->aHeader, 13);
-  if((pGIF->config.attrFlags & GIF_ATTR_NO_GLOBAL_TABLE) == 0) {
+  if((pGIF->config.attrFlags & CGIF_ATTR_NO_GLOBAL_TABLE) == 0) {
     initCodeSize = calcInitCodeLen(pGIF->config.numGlobalPaletteEntries);
     write(pGIF, pGIF->aGlobalColorTable, 3 << (initCodeSize - 1));
   }
-  if(pGIF->config.attrFlags & GIF_ATTR_IS_ANIMATED) {
+  if(pGIF->config.attrFlags & CGIF_ATTR_IS_ANIMATED) {
     write(pGIF, pGIF->aAppExt, 19);
   }
   return pGIF;
 }
 
 /* optimize GIF file size by only redrawing the rectangular area that differs from previous frame */
-static uint8_t* doWidthHeightOptim(Frame* pFrame, uint8_t const* pCurImageData, uint8_t const* pBefImageData, const uint16_t width, const uint16_t height) {
+static uint8_t* doWidthHeightOptim(CGIF_Frame* pFrame, uint8_t const* pCurImageData, uint8_t const* pBefImageData, const uint16_t width, const uint16_t height) {
   uint8_t* pNewImageData;
   uint16_t i, x;
   uint16_t newHeight, newWidth, newLeft, newTop;
@@ -456,8 +456,8 @@ Done:
 }
 
 /* add a new GIF-frame and write it */
-int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
-  Frame*   pFrame;
+int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
+  CGIF_Frame*   pFrame;
   uint8_t* pTmpImageData;
   uint8_t* pBefImageData;
   uint16_t imageWidth;
@@ -469,19 +469,19 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
   int      hasTransparency;
   
   pFrame        = pGIF->pCurFrame;
-  memcpy(&(pFrame->config), pConfig, sizeof(FrameConfig));
+  memcpy(&(pFrame->config), pConfig, sizeof(CGIF_FrameConfig));
   imageWidth    = pGIF->config.width;
   imageHeight   = pGIF->config.height;
 
   // determine fixed attributes of frame / GIF
   isFirstFrame    = ((&pGIF->firstFrame == pGIF->pCurFrame))                ? 1 : 0;
-  useLocalTable   = (pFrame->config.attrFlags & FRAME_ATTR_USE_LOCAL_TABLE) ? 1 : 0;
-  hasTransparency = (pGIF->config.attrFlags & GIF_ATTR_HAS_TRANSPARENCY)    ? 1 : 0;
+  useLocalTable   = (pFrame->config.attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? 1 : 0;
+  hasTransparency = (pGIF->config.attrFlags & CGIF_ATTR_HAS_TRANSPARENCY)    ? 1 : 0;
   // deactivate impossible size optimizations 
   //  => in case the current frame or the frame before use a local-color table or transparency
   // FRAME_GEN_USE_TRANSPARENCY and FRAME_GEN_USE_DIFF_WINDOW are not possible
-  if(isFirstFrame || useLocalTable || hasTransparency || (pFrame->pBef->config.attrFlags & FRAME_ATTR_USE_LOCAL_TABLE)) {
-    pFrame->config.genFlags &= ~(FRAME_GEN_USE_TRANSPARENCY | FRAME_GEN_USE_DIFF_WINDOW);
+  if(isFirstFrame || useLocalTable || hasTransparency || (pFrame->pBef->config.attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE)) {
+    pFrame->config.genFlags &= ~(CGIF_FRAME_GEN_USE_TRANSPARENCY | CGIF_FRAME_GEN_USE_DIFF_WINDOW);
   }
 
   // set Frame header to a clean state
@@ -505,7 +505,7 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
 
   // check if we need to increase the initial code length in order to allow the transparency optim.
   // note: In case the palette is full (256 entries) this optim is not possible
-  if(pFrame->config.genFlags & FRAME_GEN_USE_TRANSPARENCY) {
+  if(pFrame->config.genFlags & CGIF_FRAME_GEN_USE_TRANSPARENCY) {
     if(pFrame->initDictLen == pGIF->config.numGlobalPaletteEntries && pGIF->config.numGlobalPaletteEntries < 256) {
       ++(pFrame->initCodeLen);
       pFrame->initDictLen = 1uL << (pFrame->initCodeLen - 1);
@@ -518,7 +518,7 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
   memcpy(pFrame->config.pImageData, pConfig->pImageData, imageWidth * imageHeight);
 
   // purge overlap of current frame and frame before (wdith - height optim), if required (FRAME_GEN_USE_DIFF_WINDOW set)
-  if(pFrame->config.genFlags & FRAME_GEN_USE_DIFF_WINDOW) {
+  if(pFrame->config.genFlags & CGIF_FRAME_GEN_USE_DIFF_WINDOW) {
     pTmpImageData = doWidthHeightOptim(pFrame, pConfig->pImageData, pFrame->pBef->config.pImageData, imageWidth, imageHeight);
   } else {
     pFrame->width                      = imageWidth;
@@ -533,7 +533,7 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
   IMAGE_LEFT(pFrame->aImageHeader)   = hU16toLE(pFrame->left);
 
   // mark matching areas of the previous frame as transparent, if required (FRAME_GEN_USE_TRANSPARENCY set)
-  if((pFrame->config.genFlags & FRAME_GEN_USE_TRANSPARENCY) && pGIF->config.numGlobalPaletteEntries < 256) {
+  if((pFrame->config.genFlags & CGIF_FRAME_GEN_USE_TRANSPARENCY) && pGIF->config.numGlobalPaletteEntries < 256) {
     if(pTmpImageData == NULL) {
       pTmpImageData = malloc(imageWidth * imageHeight); // TBD check return value of malloc
       memcpy(pTmpImageData, pConfig->pImageData, imageWidth * imageHeight);
@@ -549,7 +549,7 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
   }
 
   // generate LZW raster data (actual image data)
-  if(((pFrame->config.genFlags & FRAME_GEN_USE_TRANSPARENCY) &&  pGIF->config.numGlobalPaletteEntries < 256) || (pFrame->config.genFlags & FRAME_GEN_USE_DIFF_WINDOW)) {
+  if(((pFrame->config.genFlags & CGIF_FRAME_GEN_USE_TRANSPARENCY) &&  pGIF->config.numGlobalPaletteEntries < 256) || (pFrame->config.genFlags & CGIF_FRAME_GEN_USE_DIFF_WINDOW)) {
     pFrame->pRasterData = LZW_GenerateStream(pFrame, pFrame->width * pFrame->height, pTmpImageData);
     free(pTmpImageData);
   } else {
@@ -560,14 +560,14 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
   if(!isFirstFrame) {
     free(pFrame->pBef->config.pImageData);
   }
-  pFrame->pNext             = malloc(sizeof(Frame)); // TBD check return value of malloc
+  pFrame->pNext             = malloc(sizeof(CGIF_Frame)); // TBD check return value of malloc
   pFrame->pNext->transIndex = 0;
   pFrame->pNext->pBef       = pFrame;
   pFrame->pNext->pNext      = NULL;
   pGIF->pCurFrame           = pFrame->pNext;
 
   // do things for animation / user-defined transparency, if necessary
-  if(pGIF->config.attrFlags & GIF_ATTR_IS_ANIMATED) {
+  if(pGIF->config.attrFlags & CGIF_ATTR_IS_ANIMATED) {
     memset(pFrame->aGraphicExt, 0, sizeof(pFrame->aGraphicExt));
     pFrame->aGraphicExt[0] = 0x21;
     pFrame->aGraphicExt[1] = 0xF9;
@@ -577,7 +577,7 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
     } else {
       pFrame->aGraphicExt[3] = 0x04; // leave previous frame
     }
-    if((pFrame->config.genFlags & FRAME_GEN_USE_TRANSPARENCY) || hasTransparency) {
+    if((pFrame->config.genFlags & CGIF_FRAME_GEN_USE_TRANSPARENCY) || hasTransparency) {
       pFrame->aGraphicExt[3] |= 0x01;
     }
     pFrame->aGraphicExt[6] = pFrame->transIndex;
@@ -586,11 +586,11 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
 
   // write frame
   initialCodeSize = pFrame->initCodeLen - 1;
-  if(pGIF->config.attrFlags & GIF_ATTR_IS_ANIMATED) {
+  if(pGIF->config.attrFlags & CGIF_ATTR_IS_ANIMATED) {
     write(pGIF, pFrame->aGraphicExt, 8);
   }
   write(pGIF, pFrame->aImageHeader, 10);
-  if(pFrame->config.attrFlags & FRAME_ATTR_USE_LOCAL_TABLE) {
+  if(pFrame->config.attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) {
     write(pGIF, pFrame->aLocalColorTable, pFrame->initDictLen * 3);
   }
   write(pGIF, &initialCodeSize, 1);
@@ -605,7 +605,7 @@ int cgif_addframe(GIF* pGIF, FrameConfig* pConfig) {
 }
 
 /* write terminate code, close the GIF-file, free allocated space */
-int cgif_close(GIF* pGIF) {
+int cgif_close(CGIF* pGIF) {
   // not first frame?
   // => free preserved image data of the frame before
   write(pGIF, (unsigned char*) ";", 1); // write term symbol

--- a/cgif.h
+++ b/cgif.h
@@ -9,29 +9,29 @@ extern "C" {
 #endif
 
 // flags to set the GIF/frame-attributes
-#define GIF_ATTR_IS_ANIMATED          (1uL << 1)       // make an animated GIF (default is non-animated GIF)
-#define GIF_ATTR_NO_GLOBAL_TABLE      (1uL << 2)       // disable global color table (global color table is default)
-#define GIF_ATTR_HAS_TRANSPARENCY     (1uL << 3)       // first entry in color table contains transparency
-#define FRAME_ATTR_USE_LOCAL_TABLE    (1uL << 0)       // use a local color table for a frame (local color table is not used by default)
+#define CGIF_ATTR_IS_ANIMATED            (1uL << 1)       // make an animated GIF (default is non-animated GIF)
+#define CGIF_ATTR_NO_GLOBAL_TABLE        (1uL << 2)       // disable global color table (global color table is default)
+#define CGIF_ATTR_HAS_TRANSPARENCY       (1uL << 3)       // first entry in color table contains transparency
+#define CGIF_FRAME_ATTR_USE_LOCAL_TABLE  (1uL << 0)       // use a local color table for a frame (local color table is not used by default)
 // flags to decrease GIF-size
-#define FRAME_GEN_USE_TRANSPARENCY    (1uL << 0)       // use transparency optimization (setting pixels identical to previous frame transparent)
-#define FRAME_GEN_USE_DIFF_WINDOW     (1uL << 1)       // do encoding just for the sub-window that has changed from previous frame
+#define CGIF_FRAME_GEN_USE_TRANSPARENCY  (1uL << 0)       // use transparency optimization (setting pixels identical to previous frame transparent)
+#define CGIF_FRAME_GEN_USE_DIFF_WINDOW   (1uL << 1)       // do encoding just for the sub-window that has changed from previous frame
 
-#define INFINITE_LOOP (0x0000uL)                       // for animated GIF: 0 specifies infinite loop
+#define CGIF_INFINITE_LOOP               (0x0000uL)       // for animated GIF: 0 specifies infinite loop
 
-typedef struct st_gif         GIF;                    // struct for the full GIF
-typedef struct st_frame       Frame;                  // struct for a single frame
-typedef struct st_gifconfig    GIFConfig;               // global cofinguration parameters of the GIF
-typedef struct st_frameconfig  FrameConfig;             // local configuration parameters for a frame
+typedef struct st_gif         CGIF;                      // struct for the full GIF
+typedef struct st_frame       CGIF_Frame;                // struct for a single frame
+typedef struct st_gifconfig    CGIF_Config;                // global cofinguration parameters of the GIF
+typedef struct st_frameconfig  CGIF_FrameConfig;           // local configuration parameters for a frame
 
 typedef int cgif_write_fn(void* pContext, const uint8_t* pData, const size_t numBytes); // callback function for stream-based output
 
 // prototypes
-GIF* cgif_newgif     (GIFConfig* pConfig);              // creates a new GIF (returns pointer to new GIF or NULL on error)
-int  cgif_addframe   (GIF* pGIF, FrameConfig* pConfig); // adds the next frame to an existing GIF (returns 0 on success)
-int  cgif_close      (GIF* pGIF);                     // close file and free allocated memory (returns 0 on success)
+CGIF* cgif_newgif     (CGIF_Config* pConfig);                  // creates a new GIF (returns pointer to new GIF or NULL on error)
+int   cgif_addframe   (CGIF* pGIF, CGIF_FrameConfig* pConfig); // adds the next frame to an existing GIF (returns 0 on success)
+int   cgif_close      (CGIF* pGIF);                          // close file and free allocated memory (returns 0 on success)
 
-// GIFConfig type (parameters passed by user)
+// CGIF_Config type (parameters passed by user)
 // note: must stay AS IS for backward compatibility
 struct st_gifconfig {
   uint8_t*    pGlobalPalette;                            // global color table of the GIF
@@ -46,7 +46,7 @@ struct st_gifconfig {
   void*       pContext;                                  // opaque pointer passed as the first parameter to pWriteFn
 };
 
-// FrameConfig type (parameters passed by user)
+// CGIF_FrameConfig type (parameters passed by user)
 // note: must stay AS IS for backward compatibility
 struct st_frameconfig {
   uint8_t*  pLocalPalette;                             // local color table of a frame
@@ -57,10 +57,10 @@ struct st_frameconfig {
   uint16_t  numLocalPaletteEntries;                    // size of the local color table
 };
 
-// Frame type
+// CGIF_Frame type
 // note: internal sections, subject to change in future versions
 struct st_frame {
-  FrameConfig        config;                             // (internal) configutation parameters of the frame (see above)
+  CGIF_FrameConfig   config;                             // (internal) configutation parameters of the frame (see above)
   struct st_frame*  pBef;                              // (internal) pointer to frame before (needed e.g. for transparency optimization)
   struct st_frame*  pNext;                             // (internal) pointer to next frame
   uint8_t*          pRasterData;                       // (internal) pointer to LZW-data
@@ -77,16 +77,16 @@ struct st_frame {
   uint8_t           initCodeLen;                       // initial length of the LZW-codes in bits (minimum 3, maximum 12)
 };
 
-// GIF type
+// CGIF type
 // note: internal sections, subject to change in future versions
 struct st_gif {
-  GIFConfig config;                                    // (internal) configutation parameters of the GIF (see above)
-  FILE*    pFile;
-  uint8_t  aHeader[13];                              // (internal) header of the GIF
-  uint8_t  aGlobalColorTable[256 * 3];               // (internal) global color table
-  uint8_t  aAppExt[19];                              //
-  Frame*   pCurFrame;                                // (internal) pointer to current frame
-  Frame    firstFrame;                                // (internal) pointer to next frame
+  CGIF_Config config;                                      // (internal) configutation parameters of the GIF (see above)
+  FILE*        pFile;
+  uint8_t      aHeader[13];                              // (internal) header of the GIF
+  uint8_t      aGlobalColorTable[256 * 3];               // (internal) global color table
+  uint8_t      aAppExt[19];                              //
+  CGIF_Frame*  pCurFrame;                                // (internal) pointer to current frame
+  CGIF_Frame   firstFrame;                                // (internal) pointer to next frame
 };
 
 #ifdef __cplusplus

--- a/cgif_example.c
+++ b/cgif_example.c
@@ -8,24 +8,24 @@
 #define HEIGHT 1024
 
 /* Small helper functions to initialize GIF- and frame-configuration */
-static void initGIFConfig(GIFConfig* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
-  memset(pConfig, 0, sizeof(GIFConfig));
+static void initGIFConfig(CGIF_Config* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
+  memset(pConfig, 0, sizeof(CGIF_Config));
   pConfig->width                   = width;
   pConfig->height                  = height;
   pConfig->pGlobalPalette          = pPalette;
   pConfig->numGlobalPaletteEntries = numColors;
   pConfig->path                    = path;
 }
-static void initFrameConfig(FrameConfig* pConfig, uint8_t* pImageData) {
-  memset(pConfig, 0, sizeof(FrameConfig));
+static void initFrameConfig(CGIF_FrameConfig* pConfig, uint8_t* pImageData) {
+  memset(pConfig, 0, sizeof(CGIF_FrameConfig));
   pConfig->pImageData = pImageData;
 }
 
 /* This is an example code that creates a GIF-image with random pixels. */
 int main(void) {
-  GIF*          pGIF;                                           // struct containing the GIF
-  GIFConfig     gConfig;                                        // global configuration parameters for the GIF
-  FrameConfig   fConfig;                                        // configuration parameters for a frame
+  CGIF*          pGIF;                                          // struct containing the GIF
+  CGIF_Config     gConfig;                                        // global configuration parameters for the GIF
+  CGIF_FrameConfig   fConfig;                                     // configuration parameters for a frame
   uint8_t*      pImageData;                                     // image data (an array of color-indices)
   uint8_t       aPalette[] = {0xFF, 0x00, 0x00,                 // red
                               0x00, 0xFF, 0x00,                 // green

--- a/cgif_example_video.c
+++ b/cgif_example_video.c
@@ -8,26 +8,26 @@
 #define HEIGHT 100
 
 /* Small helper functions to initialize GIF- and frame-configuration */
-static void initGIFConfig(GIFConfig* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
-  memset(pConfig, 0, sizeof(GIFConfig));
+static void initGIFConfig(CGIF_Config* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
+  memset(pConfig, 0, sizeof(CGIF_Config));
   pConfig->width                   = width;
   pConfig->height                  = height;
   pConfig->pGlobalPalette          = pPalette;
   pConfig->numGlobalPaletteEntries = numColors;
   pConfig->path                    = path;
-  pConfig->attrFlags               = GIF_ATTR_IS_ANIMATED;
+  pConfig->attrFlags               = CGIF_ATTR_IS_ANIMATED;
 }
-static void initFrameConfig(FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay) {
-  memset(pConfig, 0, sizeof(FrameConfig));
+static void initFrameConfig(CGIF_FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay) {
+  memset(pConfig, 0, sizeof(CGIF_FrameConfig));
   pConfig->delay      = delay;
   pConfig->pImageData = pImageData;
 }
 
 /* This is an example code that creates a GIF-animation with a moving stripe-pattern. */
 int main(void) {
-  GIF*        pGIF;                                                      // struct containing the GIF
-  GIFConfig    gConfig;                                                  // global configuration parameters for the GIF
-  FrameConfig  fConfig;                                                  // configuration parameters for a frame
+  CGIF*            pGIF;                                                 // struct containing the GIF
+  CGIF_Config       gConfig;                                               // global configuration parameters for the GIF
+  CGIF_FrameConfig  fConfig;                                               // configuration parameters for a frame
   uint8_t*    pImageData;                                                // image data (an array of color-indices)
   uint8_t aPalette[] = {0xFF, 0x00, 0x00,                                // red
                         0x00, 0xFF, 0x00,                                // green

--- a/tests/all_optim.c
+++ b/tests/all_optim.c
@@ -8,8 +8,8 @@
 #define WIDTH  100
 #define HEIGHT 100
 
-static void initGIFConfig(GIFConfig* pConfig, uint8_t* pGlobalPalette, uint16_t numColors, uint32_t attrFlags, uint16_t width, uint16_t height) {
-  memset(pConfig, 0, sizeof(GIFConfig));
+static void initGIFConfig(CGIF_Config* pConfig, uint8_t* pGlobalPalette, uint16_t numColors, uint32_t attrFlags, uint16_t width, uint16_t height) {
+  memset(pConfig, 0, sizeof(CGIF_Config));
   pConfig->attrFlags               = attrFlags;
   pConfig->width                   = width;
   pConfig->height                  = height;
@@ -18,17 +18,17 @@ static void initGIFConfig(GIFConfig* pConfig, uint8_t* pGlobalPalette, uint16_t 
   pConfig->path                   = "all_optim.gif";
 }
 
-static void initFrameConfig(FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay, uint32_t genFlags) {
-  memset(pConfig, 0, sizeof(FrameConfig));
+static void initFrameConfig(CGIF_FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay, uint32_t genFlags) {
+  memset(pConfig, 0, sizeof(CGIF_FrameConfig));
   pConfig->pImageData = pImageData;
   pConfig->delay      = delay;
   pConfig->genFlags   = genFlags;
 }
 
 int main(void) {
-  GIF*          pGIF;
-  GIFConfig      gConfig;
-  FrameConfig    fConfig;
+  CGIF*          pGIF;
+  CGIF_Config      gConfig;
+  CGIF_FrameConfig    fConfig;
   uint8_t*      pImageData;
   uint8_t aPalette[] = {
     0x00, 0x00, 0x00, // black
@@ -38,13 +38,13 @@ int main(void) {
   int numFrames     = 2;      // number of frames in the video
   //
   // create new GIF
-  initGIFConfig(&gConfig, aPalette, numColors, GIF_ATTR_IS_ANIMATED, WIDTH, HEIGHT);
+  initGIFConfig(&gConfig, aPalette, numColors, CGIF_ATTR_IS_ANIMATED, WIDTH, HEIGHT);
   pGIF = cgif_newgif(&gConfig);
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);         // Actual image data
   memset(pImageData, 0, WIDTH * HEIGHT);
-  initFrameConfig(&fConfig, pImageData, 100, FRAME_GEN_USE_TRANSPARENCY | FRAME_GEN_USE_DIFF_WINDOW);
+  initFrameConfig(&fConfig, pImageData, 100, CGIF_FRAME_GEN_USE_TRANSPARENCY | CGIF_FRAME_GEN_USE_DIFF_WINDOW);
   cgif_addframe(pGIF, &fConfig); // append the new frame
   memset(pImageData + 7, 1, 41);
   memset(pImageData + 7 + WIDTH, 1, 41);

--- a/tests/animated_single_pixel.c
+++ b/tests/animated_single_pixel.c
@@ -8,27 +8,27 @@
 #define HEIGHT 40
 
 /* Small helper functions to initialize GIF- and frame-configuration */
-static void initGIFConfig(GIFConfig* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
-  memset(pConfig, 0, sizeof(GIFConfig));
+static void initGIFConfig(CGIF_Config* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
+  memset(pConfig, 0, sizeof(CGIF_Config));
   pConfig->width                   = width;
   pConfig->height                  = height;
   pConfig->pGlobalPalette          = pPalette;
   pConfig->numGlobalPaletteEntries = numColors;
   pConfig->path                    = path;
-  pConfig->attrFlags               = GIF_ATTR_IS_ANIMATED;   
+  pConfig->attrFlags               = CGIF_ATTR_IS_ANIMATED;   
 }
-static void initFrameConfig(FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay) {
-  memset(pConfig, 0, sizeof(FrameConfig));
+static void initFrameConfig(CGIF_FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay) {
+  memset(pConfig, 0, sizeof(CGIF_FrameConfig));
   pConfig->delay      = delay;
   pConfig->pImageData = pImageData;
-  pConfig->genFlags = FRAME_GEN_USE_TRANSPARENCY | FRAME_GEN_USE_DIFF_WINDOW; // use optimizations
+  pConfig->genFlags = CGIF_FRAME_GEN_USE_TRANSPARENCY | CGIF_FRAME_GEN_USE_DIFF_WINDOW; // use optimizations
 }
 
 /* This is an example code that creates a GIF-animation with a single moving pixel. */
 int main(void) {
-  GIF*        pGIF;                                                      // struct containing the GIF
-  GIFConfig    gConfig;                                                  // global configuration parameters for the GIF
-  FrameConfig  fConfig;                                                  // configuration parameters for a frame
+  CGIF*        pGIF;                                                      // struct containing the GIF
+  CGIF_Config    gConfig;                                                  // global configuration parameters for the GIF
+  CGIF_FrameConfig  fConfig;                                                  // configuration parameters for a frame
   uint8_t*    pImageData;                                                // image data (an array of color-indices)
   int x,y;                                                               // position of the pixel
   uint8_t aPalette[] = {0xFF, 0x00, 0x00,                                // red

--- a/tests/animated_snake.c
+++ b/tests/animated_snake.c
@@ -8,27 +8,27 @@
 #define HEIGHT 40
 
 /* Small helper functions to initialize GIF- and frame-configuration */
-static void initGIFConfig(GIFConfig* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
-  memset(pConfig, 0, sizeof(GIFConfig));
+static void initGIFConfig(CGIF_Config* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
+  memset(pConfig, 0, sizeof(CGIF_Config));
   pConfig->width                   = width;
   pConfig->height                  = height;
   pConfig->pGlobalPalette          = pPalette;
   pConfig->numGlobalPaletteEntries = numColors;
   pConfig->path                    = path;
-  pConfig->attrFlags               = GIF_ATTR_IS_ANIMATED;   
+  pConfig->attrFlags               = CGIF_ATTR_IS_ANIMATED;   
 }
-static void initFrameConfig(FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay) {
-  memset(pConfig, 0, sizeof(FrameConfig));
+static void initFrameConfig(CGIF_FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay) {
+  memset(pConfig, 0, sizeof(CGIF_FrameConfig));
   pConfig->delay      = delay;
   pConfig->pImageData = pImageData;
-  pConfig->genFlags = FRAME_GEN_USE_TRANSPARENCY | FRAME_GEN_USE_DIFF_WINDOW; // use optimizations
+  pConfig->genFlags = CGIF_FRAME_GEN_USE_TRANSPARENCY | CGIF_FRAME_GEN_USE_DIFF_WINDOW; // use optimizations
 }
 
 /* This is an example code that creates a GIF-animation with a moving snake. */
 int main(void) {
-  GIF*        pGIF;                                                      // struct containing the GIF
-  GIFConfig    gConfig;                                                  // global configuration parameters for the GIF
-  FrameConfig  fConfig;                                                  // configuration parameters for a frame
+  CGIF*        pGIF;                                                      // struct containing the GIF
+  CGIF_Config    gConfig;                                                  // global configuration parameters for the GIF
+  CGIF_FrameConfig  fConfig;                                                  // configuration parameters for a frame
   uint8_t*    pImageData;                                                // image data (an array of color-indices)
   int x,y,x1,y1;                                                         // position of snake beginning and end
   uint8_t aPalette[] = {0xFF, 0x00, 0x00,                                // red

--- a/tests/animated_stripe_pattern.c
+++ b/tests/animated_stripe_pattern.c
@@ -9,9 +9,9 @@
 
 /* This is an example code that creates a GIF-animation with a moving stripe-pattern. */
 int main(void) {
-  GIF*          pGIF;
-  GIFConfig      gConfig;
-  FrameConfig    fConfig;
+  CGIF*          pGIF;
+  CGIF_Config      gConfig;
+  CGIF_FrameConfig    fConfig;
   uint8_t*      pImageData;
   uint8_t       aPalette[] = {
     0x00, 0x00, 0x00, // black
@@ -23,9 +23,9 @@ int main(void) {
   uint8_t numColors   = 5;  // number of colors in aPalette
   int numFrames       = 30; // number of frames in the video
   
-  memset(&gConfig, 0, sizeof(GIFConfig));
-  memset(&fConfig, 0, sizeof(FrameConfig));
-  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED; // set needed attribution flag (as GIF is animated) 
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_IS_ANIMATED; // set needed attribution flag (as GIF is animated) 
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
@@ -37,7 +37,7 @@ int main(void) {
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);         // actual image data
-  fConfig.genFlags   = FRAME_GEN_USE_DIFF_WINDOW | FRAME_GEN_USE_TRANSPARENCY;
+  fConfig.genFlags   = CGIF_FRAME_GEN_USE_DIFF_WINDOW | CGIF_FRAME_GEN_USE_TRANSPARENCY;
   fConfig.pImageData = pImageData;             // set pointer to image data
   fConfig.delay      = 10;                     // set time before next frame (in units of 0.01 s)
   for (int f = 0; f < numFrames; ++f) {

--- a/tests/animated_stripe_pattern_2.c
+++ b/tests/animated_stripe_pattern_2.c
@@ -8,27 +8,27 @@
 #define HEIGHT 100
 
 /* Small helper functions to initialize GIF- and frame-configuration */
-static void initGIFConfig(GIFConfig* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
-  memset(pConfig, 0, sizeof(GIFConfig));
+static void initGIFConfig(CGIF_Config* pConfig, char* path, uint16_t width, uint16_t height, uint8_t* pPalette, uint16_t numColors) {
+  memset(pConfig, 0, sizeof(CGIF_Config));
   pConfig->width                   = width;
   pConfig->height                  = height;
   pConfig->pGlobalPalette          = pPalette;
   pConfig->numGlobalPaletteEntries = numColors;
   pConfig->path                    = path;
-  pConfig->attrFlags               = GIF_ATTR_IS_ANIMATED;   
+  pConfig->attrFlags               = CGIF_ATTR_IS_ANIMATED;   
 }
-static void initFrameConfig(FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay) {
-  memset(pConfig, 0, sizeof(FrameConfig));
+static void initFrameConfig(CGIF_FrameConfig* pConfig, uint8_t* pImageData, uint16_t delay) {
+  memset(pConfig, 0, sizeof(CGIF_FrameConfig));
   pConfig->delay      = delay;
   pConfig->pImageData = pImageData;
-  pConfig->genFlags = FRAME_GEN_USE_TRANSPARENCY | FRAME_GEN_USE_DIFF_WINDOW; // use optimizations
+  pConfig->genFlags = CGIF_FRAME_GEN_USE_TRANSPARENCY | CGIF_FRAME_GEN_USE_DIFF_WINDOW; // use optimizations
 }
 
 /* This is an example code that creates a GIF-animation with a moving stripe-pattern in part of the frame. */
 int main(void) {
-  GIF*        pGIF;                                                      // struct containing the GIF
-  GIFConfig    gConfig;                                                  // global configuration parameters for the GIF
-  FrameConfig  fConfig;                                                  // configuration parameters for a frame
+  CGIF*        pGIF;                                                      // struct containing the GIF
+  CGIF_Config    gConfig;                                                  // global configuration parameters for the GIF
+  CGIF_FrameConfig  fConfig;                                                  // configuration parameters for a frame
   uint8_t*    pImageData;                                                // image data (an array of color-indices)
   uint8_t aPalette[] = {0xFF, 0x00, 0x00,                                // red
                         0x00, 0xFF, 0x00,                                // green

--- a/tests/animated_stripes_horizontal.c
+++ b/tests/animated_stripes_horizontal.c
@@ -9,9 +9,9 @@
 
 /* This is an example code that creates a GIF-animation with a moving stripe-pattern. */
 int main(void) {
-  GIF*          pGIF;
-  GIFConfig      gConfig;
-  FrameConfig    fConfig;
+  CGIF*          pGIF;
+  CGIF_Config      gConfig;
+  CGIF_FrameConfig    fConfig;
   uint8_t*      pImageData;
   uint8_t       aPalette[] = {
     0xFF, 0x00, 0x00,
@@ -28,9 +28,9 @@ int main(void) {
   uint8_t numColors   = 10;  // number of colors in aPalette
   int numFrames       = 10; // number of frames in the video
   
-  memset(&gConfig, 0, sizeof(GIFConfig));
-  memset(&fConfig, 0, sizeof(FrameConfig));
-  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED; // set needed attribution flag (as GIF is animated) 
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_IS_ANIMATED; // set needed attribution flag (as GIF is animated) 
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
@@ -42,7 +42,7 @@ int main(void) {
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);         // actual image data
-  fConfig.genFlags   = FRAME_GEN_USE_DIFF_WINDOW | FRAME_GEN_USE_TRANSPARENCY;
+  fConfig.genFlags   = CGIF_FRAME_GEN_USE_DIFF_WINDOW | CGIF_FRAME_GEN_USE_TRANSPARENCY;
   fConfig.pImageData = pImageData;             // set pointer to image data
   fConfig.delay      = 50;                     // set time before next frame (in units of 0.01 s)
   for (int f = 0; f < numFrames; ++f) {

--- a/tests/global_plus_local_table.c
+++ b/tests/global_plus_local_table.c
@@ -10,9 +10,9 @@
 
 /* This is an example code that creates a GIF-animation with a moving stripe-pattern. */
 int main(void) {
-  GIF*         pGIF;
-  GIFConfig     gConfig;
-  FrameConfig   fConfig;
+  CGIF*         pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t aLocalPalette[] = {
     0x00, 0x00, 0x00, // black
@@ -28,11 +28,11 @@ int main(void) {
   //
   // Create new GIF
   //
-  memset(&gConfig, 0, sizeof(GIFConfig));
-  memset(&fConfig, 0, sizeof(FrameConfig));
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
   gConfig.pGlobalPalette               = aGlobalPalette;
   gConfig.numGlobalPaletteEntries = numColorsGlobal;
-  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED;
+  gConfig.attrFlags               = CGIF_ATTR_IS_ANIMATED;
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.path                    = "global_plus_local_table.gif";
@@ -46,13 +46,13 @@ int main(void) {
   fConfig.pImageData = pImageData;
   fConfig.pLocalPalette = aLocalPalette;
   fConfig.numLocalPaletteEntries = numColorsLocal;
-  fConfig.attrFlags = FRAME_ATTR_USE_LOCAL_TABLE;
+  fConfig.attrFlags = CGIF_FRAME_ATTR_USE_LOCAL_TABLE;
   fConfig.delay = 100;
   cgif_addframe(pGIF, &fConfig); // append the new frame
   //
   // add next frame
   fConfig.attrFlags = 0;
-  fConfig.genFlags = FRAME_GEN_USE_TRANSPARENCY;
+  fConfig.genFlags = CGIF_FRAME_GEN_USE_TRANSPARENCY;
   memset(pImageData + WIDTH * 9, 2, WIDTH * 10);
   cgif_addframe(pGIF, &fConfig); // append the new frame
   //

--- a/tests/has_transparency.c
+++ b/tests/has_transparency.c
@@ -8,18 +8,18 @@
 #define HEIGHT 99
 
 int main(void) {
-  GIF*          pGIF;
-  GIFConfig     gConfig;
-  FrameConfig   fConfig;
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t       aPalette[] = {
     0x00, 0x00, 0x00, // black (transparent)
     0xFF, 0xFF, 0xFF, // white
   };
 
-  memset(&gConfig, 0, sizeof(GIFConfig));
-  memset(&fConfig, 0, sizeof(FrameConfig));
-  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED | GIF_ATTR_HAS_TRANSPARENCY;  // first entry in color table is transparency
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_IS_ANIMATED | CGIF_ATTR_HAS_TRANSPARENCY;  // first entry in color table is transparency
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;

--- a/tests/has_transparency_2.c
+++ b/tests/has_transparency_2.c
@@ -8,18 +8,18 @@
 #define HEIGHT 99
 
 int main(void) {
-  GIF*          pGIF;
-  GIFConfig     gConfig;
-  FrameConfig   fConfig;
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t       aPalette[] = {
     0x00, 0x00, 0x00, // black (transparent)
     0xFF, 0xFF, 0xFF, // white
   };
 
-  memset(&gConfig, 0, sizeof(GIFConfig));
-  memset(&fConfig, 0, sizeof(FrameConfig));
-  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED | GIF_ATTR_HAS_TRANSPARENCY;  // first entry in color table is transparency
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_IS_ANIMATED | CGIF_ATTR_HAS_TRANSPARENCY;  // first entry in color table is transparency
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;

--- a/tests/max_color_table_test.c
+++ b/tests/max_color_table_test.c
@@ -9,9 +9,9 @@
 
 /* This is an example code that creates a GIF-image with all green pixels. */
 int main(void) {
-  GIF*         pGIF;
-  GIFConfig     gConfig;
-  FrameConfig   fConfig;
+  CGIF*         pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t*      aPalette;
   uint16_t      numColors         = 256; // number of colors in aPalette  
@@ -23,7 +23,7 @@ int main(void) {
   memset(pImageData, 0, WIDTH * HEIGHT);
   //
   // create new GIF
-  memset(&gConfig, 0, sizeof(GIFConfig));
+  memset(&gConfig, 0, sizeof(CGIF_Config));
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
@@ -32,7 +32,7 @@ int main(void) {
   pGIF = cgif_newgif(&gConfig);  
   //
   // add frames to GIF
-  memset(&fConfig, 0, sizeof(FrameConfig));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
   fConfig.pImageData = pImageData;
   cgif_addframe(pGIF, &fConfig);
   free(pImageData);  

--- a/tests/min_color_table_test.c
+++ b/tests/min_color_table_test.c
@@ -9,9 +9,9 @@
 
 /* This is an example code that creates a GIF-image with all green pixels. */
 int main(void) {
-  GIF*         pGIF;
-  GIFConfig     gConfig;
-  FrameConfig   fConfig;
+  CGIF*         pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t       aPalette[] = { 0x00, 0xFF, 0x00 }; // green
   uint8_t       numColors  = 1; // number of colors in aPalette  
@@ -21,7 +21,7 @@ int main(void) {
   memset(pImageData, 0, WIDTH * HEIGHT); // set to all green   
   //
   // create new GIF
-  memset(&gConfig, 0, sizeof(GIFConfig));
+  memset(&gConfig, 0, sizeof(CGIF_Config));
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
@@ -30,7 +30,7 @@ int main(void) {
   pGIF = cgif_newgif(&gConfig);  
   //
   // add frames to GIF
-  memset(&fConfig, 0, sizeof(FrameConfig));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
   fConfig.pImageData = pImageData;
   cgif_addframe(pGIF, &fConfig);
   free(pImageData);  

--- a/tests/only_local_table.c
+++ b/tests/only_local_table.c
@@ -10,9 +10,9 @@
 
 /* This is an example code that creates a GIF-animation with a moving stripe-pattern. */
 int main(void) {
-  GIF*         pGIF;
-  GIFConfig     gConfig;
-  FrameConfig   fConfig;
+  CGIF*         pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t aPalette[] = {
     0x00, 0x00, 0x00, // black
@@ -22,9 +22,9 @@ int main(void) {
   //
   // Create new GIF
   //
-  memset(&gConfig, 0, sizeof(GIFConfig));
-  memset(&fConfig, 0, sizeof(FrameConfig));
-  gConfig.attrFlags               = GIF_ATTR_NO_GLOBAL_TABLE;
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_NO_GLOBAL_TABLE;
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.path                    = "only_local_table.gif";
@@ -38,7 +38,7 @@ int main(void) {
   fConfig.pImageData = pImageData;
   fConfig.pLocalPalette = aPalette;
   fConfig.numLocalPaletteEntries = numColors;
-  fConfig.attrFlags = FRAME_ATTR_USE_LOCAL_TABLE;
+  fConfig.attrFlags = CGIF_FRAME_ATTR_USE_LOCAL_TABLE;
   cgif_addframe(pGIF, &fConfig); // append the new frame
   //
   free(pImageData);

--- a/tests/overlap_everything.c
+++ b/tests/overlap_everything.c
@@ -10,9 +10,9 @@
 
 /* This is an example code that creates a GIF-animation with a moving stripe-pattern. */
 int main(void) {
-  GIF*         pGIF;
-  GIFConfig     gConfig;
-  FrameConfig   fConfig;
+  CGIF*         pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t aPalette[] = {
     0x00, 0x00, 0x00, // black
@@ -23,9 +23,9 @@ int main(void) {
   //
   // Create new GIF
   //
-  memset(&gConfig, 0, sizeof(GIFConfig));
-  memset(&fConfig, 0, sizeof(FrameConfig));
-  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED;
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_IS_ANIMATED;
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
@@ -39,7 +39,7 @@ int main(void) {
   memset(pImageData, 0, WIDTH * HEIGHT); 
   fConfig.pImageData = pImageData;
   fConfig.delay      = 100;  // set time before next frame (in units of 0.01 s)
-  fConfig.genFlags   = FRAME_GEN_USE_DIFF_WINDOW;
+  fConfig.genFlags   = CGIF_FRAME_GEN_USE_DIFF_WINDOW;
   cgif_addframe(pGIF, &fConfig); // append the new frame
   cgif_addframe(pGIF, &fConfig); // append the next frame
   //

--- a/tests/overlap_some_rows.c
+++ b/tests/overlap_some_rows.c
@@ -10,9 +10,9 @@
 
 /* This is an example code that creates a GIF-animation with a moving stripe-pattern. */
 int main(void) {
-  GIF*         pGIF;
-  GIFConfig     gConfig;
-  FrameConfig   fConfig;
+  CGIF*         pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t aPalette[] = {
     0x00, 0x00, 0x00, // black
@@ -23,9 +23,9 @@ int main(void) {
   //
   // Create new GIF
   //
-  memset(&gConfig, 0, sizeof(GIFConfig));
-  memset(&fConfig, 0, sizeof(FrameConfig));
-  gConfig.attrFlags               = GIF_ATTR_IS_ANIMATED;
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_IS_ANIMATED;
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;
@@ -39,7 +39,7 @@ int main(void) {
   memset(pImageData, 0, WIDTH * HEIGHT); 
   fConfig.pImageData = pImageData;
   fConfig.delay      = 100;  // set time before next frame (in units of 0.01 s)
-  fConfig.genFlags   = FRAME_GEN_USE_DIFF_WINDOW;
+  fConfig.genFlags   = CGIF_FRAME_GEN_USE_DIFF_WINDOW;
   cgif_addframe(pGIF, &fConfig); // append the new frame
   memset(pImageData + 7, 1, 55);
   memset(pImageData + 7 + WIDTH, 1, 55);

--- a/tests/write_fn.c
+++ b/tests/write_fn.c
@@ -12,9 +12,9 @@ static int pWriteFn(void* pContext, const uint8_t* pData, const size_t numBytes)
 }
 
 int main(void) {
-  GIF*          pGIF;
-  GIFConfig     gConfig;
-  FrameConfig   fConfig;
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t       aPalette[] = {
     0x00, 0x00, 0x00, // black
@@ -23,8 +23,8 @@ int main(void) {
 
   FILE* file = fopen("write_fn.gif", "wb");
 
-  memset(&gConfig, 0, sizeof(GIFConfig));
-  memset(&fConfig, 0, sizeof(FrameConfig));
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
   gConfig.width                   = WIDTH;
   gConfig.height                  = HEIGHT;
   gConfig.pGlobalPalette          = aPalette;


### PR DESCRIPTION
Add namespacing for CGIF as suggested in #1.
**Note:** Breaks existing code - OK as no tagged release / version defined yet.