### PR TITLE
Improve LZW encoding speed

### DIFF
--- a/cgif.c
+++ b/cgif.c
@@ -129,7 +129,7 @@ static uint32_t lzw_crawl_tree(LZWGenState* pContext, uint32_t strPos, uint16_t 
   pTreeInit = pContext->pTreeInit;
   pTreeList = pContext->pTreeList;
   // get the next LZW code from pTreeInit:
-  // the initial nodes (0-255 max) do have more childs in average.
+  // the initial nodes (0-255 max) have more children on average.
   // use the mapping approach right from the start for these nodes.
   if(strPos < (pContext->numPixel - 1)) {
     nextParent = pTreeInit[parentIndex * initDictLen + pContext->pImageData[strPos + 1]];
@@ -282,7 +282,7 @@ static uint8_t* LZW_GenerateStream(CGIF_Frame* pFrame, const uint32_t numPixel, 
   pContext             = malloc(sizeof(LZWGenState)); // TBD check return value of malloc
   pContext->pTreeInit  = malloc((pFrame->initDictLen * sizeof(uint16_t)) * pFrame->initDictLen); // TBD check return value of malloc
   pContext->pTreeList  = malloc(((sizeof(uint16_t) * 2) + sizeof(uint16_t)) * MAX_DICT_LEN); // TBD check return value of malloc TBD check size
-  pContext->pTreeMap   = malloc((((MAX_DICT_LEN) / 2) + 1) * (pFrame->initDictLen * sizeof(uint16_t))); // TBD check return value of malloc
+  pContext->pTreeMap   = malloc(((MAX_DICT_LEN / 2) + 1) * (pFrame->initDictLen * sizeof(uint16_t))); // TBD check return value of malloc
   pContext->numPixel   = numPixel;
   pContext->pImageData = pImageData;
   pContext->pLZWData   = malloc(sizeof(uint16_t) * (numPixel + 2)); // TBD check return value of malloc

--- a/cgif.c
+++ b/cgif.c
@@ -77,29 +77,26 @@ static void resetDict(LZWGenState* pContext, const uint16_t initDictLen) {
 }
 
 /* add new child node */
-static void add_child(LZWGenState* pContext, const uint16_t parentIndex, const uint16_t LZWIndex, const uint16_t initDictLen, const uint8_t index) {
+static void add_child(LZWGenState* pContext, const uint16_t parentIndex, const uint16_t LZWIndex, const uint16_t initDictLen, const uint8_t nextColor) {
   uint16_t* pTreeList;
   uint16_t  mapPos;
 
   pTreeList = pContext->pTreeList;
   mapPos    = pTreeList[parentIndex * (2 + 1)];
-  if(!mapPos) {
-    // no free child? - we need to switch to the backup LZW mapping
-    if(pTreeList[parentIndex * (2 + 1) + 2]) {
+  if(!mapPos) { // if pTreeMap is not used yet for the parent node
+    if(pTreeList[parentIndex * (2 + 1) + 2]) { // if at least one child node exists, switch to pTreeMap
       mapPos = pContext->mapPos;
-      // add child to mapping table
+      // add child to mapping table (pTreeMap)
       memset(pContext->pTreeMap + ((mapPos - 1) * initDictLen), 0, initDictLen * sizeof(uint16_t));
-      pContext->pTreeMap[(mapPos - 1) * initDictLen + index] = LZWIndex;
+      pContext->pTreeMap[(mapPos - 1) * initDictLen + nextColor] = LZWIndex;
       pTreeList[parentIndex * (2 + 1)]  = mapPos;
       ++(pContext->mapPos);
-    } else {
-      // value = index
-      // next  = LZWIndex
-      pTreeList[parentIndex * (2 + 1) + 1] = index;
-      pTreeList[parentIndex * (2 + 1) + 2] = LZWIndex;
+    } else { // use the free spot in pTreeList for the child node
+      pTreeList[parentIndex * (2 + 1) + 1] = nextColor; // color that leads to child node
+      pTreeList[parentIndex * (2 + 1) + 2] = LZWIndex; // position of child node
     }
-  } else {
-    pContext->pTreeMap[(mapPos - 1) * initDictLen + index] = LZWIndex;
+  } else { // directly add child node to pTreeMap
+    pContext->pTreeMap[(mapPos - 1) * initDictLen + nextColor] = LZWIndex;
   }
   ++(pContext->dictPos); // increase current position in the dictionary
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,6 +12,8 @@ tests = [
   'has_transparency_2',
   'max_color_table_test',
   'min_color_table_test',
+  'noise256',
+  'noise6',
   'only_local_table',
   'overlap_everything',
   'overlap_some_rows',

--- a/tests/noise256.c
+++ b/tests/noise256.c
@@ -1,0 +1,52 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "cgif.h"
+
+#define WIDTH  500
+#define HEIGHT 500
+
+static uint64_t seed;
+
+int psdrand(void) {
+  // simple pseudo random function from musl libc
+  seed = 6364136223846793005ULL * seed + 1;
+  return seed >> 33;
+}
+
+int main(void) {
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[256 * 3]; 
+
+  seed = 22;
+  for(int i = 0; i < 256; ++i) {
+    aPalette[i * 3]     = psdrand() % 256;
+    aPalette[i * 3 + 1] = psdrand() % 256;
+    aPalette[i * 3 + 2] = psdrand() % 256;
+  }
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 256;
+  gConfig.path                    = "noise256.gif";
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  for(int i = 0; i < WIDTH * HEIGHT; ++i) pImageData[i] = psdrand() % 256;
+  fConfig.pImageData = pImageData;
+  cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  cgif_close(pGIF); // free allocated space at the end of the session
+  return 0;
+}

--- a/tests/noise6.c
+++ b/tests/noise6.c
@@ -1,0 +1,52 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "cgif.h"
+
+#define WIDTH  700
+#define HEIGHT 320
+
+static uint64_t seed;
+
+int psdrand(void) {
+  // simple pseudo random function from musl libc
+  seed = 6364136223846793005ULL * seed + 1;
+  return seed >> 33;
+}
+
+int main(void) {
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[6 * 3]; 
+
+  seed = 42;
+  for(int i = 0; i < 6; ++i) {
+    aPalette[i * 3]     = psdrand() % 256;
+    aPalette[i * 3 + 1] = psdrand() % 256;
+    aPalette[i * 3 + 2] = psdrand() % 256;
+  }
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 6;
+  gConfig.path                    = "noise6.gif";
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  for(int i = 0; i < WIDTH * HEIGHT; ++i) pImageData[i] = psdrand() % 6;
+  fConfig.pImageData = pImageData;
+  cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  cgif_close(pGIF); // free allocated space at the end of the session
+  return 0;
+}

--- a/tests/tests.md5
+++ b/tests/tests.md5
@@ -11,6 +11,8 @@ a8c2e6153396de90eaa1947178b1e383  animated_stripe_pattern.gif
 c8bc7f745090e5f386e2c69f697c1343  has_transparency.gif
 8c0e65694eef4f3ed986381cfe914b50  max_color_table_test.gif
 30ab701c8e56bc8b09c824305002de5a  min_color_table_test.gif
+c6a8e6f6d6d0c969cb300ea7eb18391d  noise256.gif
+7de24bdbff1dec81aab1840bcf69b19f  noise6.gif
 a7c04cb7b6d19a16023497da03384408  only_local_table.gif
 013513307101f1d6b80164cdb3318c1c  overlap_everything.gif
 e9e789738541e15028dfe2abdbc67314  overlap_some_rows.gif


### PR DESCRIPTION
Most time of encoding is spent in the LZW routines. 
Increase LZW encoding speed by improving cache affinity.
The memory usage has been decreased as well.

**ToDo:**
- [x] Do benchmarks to verify the speed improvement
- [x] Extend tests and add tests that fully utilize the pTreeMap (backup LZW mapping tree)