### PR TITLE
Fix encoding huge GIF frames

### DIFF
--- a/cgif.c
+++ b/cgif.c
@@ -39,6 +39,8 @@
 #define MAX_DICT_LEN    (1uL << MAX_CODE_LEN) // maximum length of the dictionary
 #define BLOCK_SIZE      0xFF                  // number of bytes in one block of the image data
 
+#define MULU16(a, b) (((uint32_t)a) * ((uint32_t)b)) // helper macro to correctly multiply two U16's without default signed int promotion
+
 typedef struct {
   uint16_t*       pTreeInit;  // LZW dictionary tree for the initial dictionary (0-255 max)
   uint16_t*       pTreeList;  // LZW dictionary tree as list (max. number of children per node = 1)
@@ -475,8 +477,8 @@ static uint8_t* doWidthHeightOptim(CGIF* pGIF, CGIF_Frame* pFrame, uint8_t const
   i = 0;
   while(i < height) {
     for(int c = 0; c < width; ++c) {
-      iCur = *(pCurImageData + i * width + c);
-      iBef = *(pBefImageData + i * width + c);
+      iCur = *(pCurImageData + MULU16(i, width) + c);
+      iBef = *(pBefImageData + MULU16(i, width) + c);
       if(cmpPixel(pGIF, pFrame, pFrame->pBef, iCur, iBef) != 0) {
         goto FoundTop;
       }
@@ -498,8 +500,8 @@ FoundTop:
   i = height - 1;
   while(i > newTop) {
     for(int c = 0; c < width; ++c) {
-      iCur = *(pCurImageData + i * width + c);
-      iBef = *(pBefImageData + i * width + c);
+      iCur = *(pCurImageData + MULU16(i, width) + c);
+      iBef = *(pBefImageData + MULU16(i, width) + c);
       if(cmpPixel(pGIF, pFrame, pFrame->pBef, iCur, iBef) != 0) {
         goto FoundHeight;
       }
@@ -512,7 +514,7 @@ FoundHeight:
   // find left
   i = newTop;
   x = 0;
-  while(cmpPixel(pGIF, pFrame, pFrame->pBef, pCurImageData[i * width + x], pBefImageData[i * width + x]) == 0) {
+  while(cmpPixel(pGIF, pFrame, pFrame->pBef, pCurImageData[MULU16(i, width) + x], pBefImageData[MULU16(i, width) + x]) == 0) {
     ++i;
     if(i > (newTop + newHeight - 1)) {
       ++x; //(x==width cannot happen as goto Done is triggered in the only possible case before)
@@ -524,7 +526,7 @@ FoundHeight:
   // find actual width
   i = newTop;
   x = width - 1;
-  while(cmpPixel(pGIF, pFrame, pFrame->pBef, pCurImageData[i * width + x], pBefImageData[i * width + x]) == 0) {
+  while(cmpPixel(pGIF, pFrame, pFrame->pBef, pCurImageData[MULU16(i, width) + x], pBefImageData[MULU16(i, width) + x]) == 0) {
     ++i;
     if(i > (newTop + newHeight - 1)) {
       --x; //(x<newLeft cannot happen as goto Done is triggered in the only possible case before)
@@ -536,9 +538,9 @@ FoundHeight:
 Done:
 
   // create new image data
-  pNewImageData = malloc(newWidth * newHeight); // TBD check return value of malloc
+  pNewImageData = malloc(MULU16(newWidth, newHeight)); // TBD check return value of malloc
   for (i = 0; i < newHeight; ++i) {
-    memcpy(pNewImageData + i * newWidth, pCurImageData + (i + newTop) * width + newLeft, newWidth);
+    memcpy(pNewImageData + MULU16(i, newWidth), pCurImageData + MULU16((i + newTop), width) + newLeft, newWidth);
   }
   
   // set new width, height, top, left in Frame struct
@@ -616,8 +618,8 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
   }
 
   // copy given raw image data into the new CGIF_FrameConfig, as we might need it in a later stage.
-  pFrame->config.pImageData = malloc(imageWidth * imageHeight); // TBD check return value of malloc
-  memcpy(pFrame->config.pImageData, pConfig->pImageData, imageWidth * imageHeight);
+  pFrame->config.pImageData = malloc(MULU16(imageWidth, imageHeight)); // TBD check return value of malloc
+  memcpy(pFrame->config.pImageData, pConfig->pImageData, MULU16(imageWidth, imageHeight));
 
   // purge overlap of current frame and frame before (wdith - height optim), if required (CGIF_FRAME_GEN_USE_DIFF_WINDOW set)
   if(pFrame->config.genFlags & CGIF_FRAME_GEN_USE_DIFF_WINDOW) {
@@ -637,14 +639,14 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
   // mark matching areas of the previous frame as transparent, if required (CGIF_FRAME_GEN_USE_TRANSPARENCY set)
   if(pFrame->config.genFlags & CGIF_FRAME_GEN_USE_TRANSPARENCY) {
     if(pTmpImageData == NULL) {
-      pTmpImageData = malloc(imageWidth * imageHeight); // TBD check return value of malloc
-      memcpy(pTmpImageData, pConfig->pImageData, imageWidth * imageHeight);
+      pTmpImageData = malloc(MULU16(imageWidth, imageHeight)); // TBD check return value of malloc
+      memcpy(pTmpImageData, pConfig->pImageData, MULU16(imageWidth, imageHeight));
     }
     pBefImageData = pFrame->pBef->config.pImageData;
     for(i = 0; i < pFrame->height; ++i) {
       for(x = 0; x < pFrame->width; ++x) {
-        if(cmpPixel(pGIF, pFrame, pFrame->pBef, pTmpImageData[i * pFrame->width + x], pBefImageData[((pFrame->top + i) * imageWidth) + (pFrame->left + x)]) == 0) {
-          pTmpImageData[i * pFrame->width + x] = pFrame->transIndex;
+        if(cmpPixel(pGIF, pFrame, pFrame->pBef, pTmpImageData[MULU16(i, pFrame->width) + x], pBefImageData[MULU16(pFrame->top + i, imageWidth) + (pFrame->left + x)]) == 0) {
+          pTmpImageData[MULU16(i, pFrame->width) + x] = pFrame->transIndex;
         }
       }
     }
@@ -652,10 +654,10 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
 
   // generate LZW raster data (actual image data)
   if((pFrame->config.genFlags & CGIF_FRAME_GEN_USE_TRANSPARENCY) || (pFrame->config.genFlags & CGIF_FRAME_GEN_USE_DIFF_WINDOW)) {
-    pFrame->pRasterData = LZW_GenerateStream(pFrame, pFrame->width * pFrame->height, pTmpImageData);
+    pFrame->pRasterData = LZW_GenerateStream(pFrame, MULU16(pFrame->width, pFrame->height), pTmpImageData);
     free(pTmpImageData);
   } else {
-    pFrame->pRasterData = LZW_GenerateStream(pFrame, imageWidth * imageHeight, pConfig->pImageData);
+    pFrame->pRasterData = LZW_GenerateStream(pFrame, MULU16(imageWidth, imageHeight), pConfig->pImageData);
   }
 
   // cleanup

--- a/tests/max_size.c
+++ b/tests/max_size.c
@@ -1,0 +1,41 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "cgif.h"
+
+#define WIDTH  0xFFFFUL
+#define HEIGHT 0xFFFFUL
+
+/* This is an example code that creates a GIF-image with all green pixels. */
+int main(void) {
+  CGIF*         pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = { 0xFF, 0x00, 0x00 };
+  uint16_t      numColors  = 1; // number of colors in aPalette  
+  //
+  // create an image
+  pImageData = malloc(WIDTH * HEIGHT);   // actual image data
+  memset(pImageData, 0, WIDTH * HEIGHT);
+  //
+  // create new GIF
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = numColors;
+  gConfig.path                    = "max_size.gif";
+  pGIF = cgif_newgif(&gConfig);  
+  //
+  // add frames to GIF
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  fConfig.pImageData = pImageData;
+  cgif_addframe(pGIF, &fConfig);
+  free(pImageData);  
+  //
+  // free allocated space at the end of the session
+  cgif_close(pGIF);  
+  return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,6 +12,7 @@ tests = [
   'has_transparency_2',
   'max_color_table_test',
   'min_color_table_test',
+  'min_size',
   'noise256',
   'noise6',
   'only_local_table',

--- a/tests/min_size.c
+++ b/tests/min_size.c
@@ -1,0 +1,41 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "cgif.h"
+
+#define WIDTH  1 
+#define HEIGHT 1 
+
+/* This is an example code that creates a GIF-image with all green pixels. */
+int main(void) {
+  CGIF*         pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = { 0xFF, 0x00, 0x00 };
+  uint16_t      numColors  = 1; // number of colors in aPalette  
+  //
+  // create an image
+  pImageData = malloc(WIDTH * HEIGHT);   // actual image data
+  memset(pImageData, 0, WIDTH * HEIGHT);
+  //
+  // create new GIF
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = numColors;
+  gConfig.path                    = "min_size.gif";
+  pGIF = cgif_newgif(&gConfig);  
+  //
+  // add frames to GIF
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  fConfig.pImageData = pImageData;
+  cgif_addframe(pGIF, &fConfig);
+  free(pImageData);  
+  //
+  // free allocated space at the end of the session
+  cgif_close(pGIF);  
+  return 0;
+}

--- a/tests/tests.md5
+++ b/tests/tests.md5
@@ -10,7 +10,9 @@ a8c2e6153396de90eaa1947178b1e383  animated_stripe_pattern.gif
 3eda7f993b36270db09929a289a5a106  has_transparency_2.gif
 c8bc7f745090e5f386e2c69f697c1343  has_transparency.gif
 8c0e65694eef4f3ed986381cfe914b50  max_color_table_test.gif
+# too large for CI: dd8cb01f5b02c16cc346b51d1faadc63  max_size.gif
 30ab701c8e56bc8b09c824305002de5a  min_color_table_test.gif
+f2bfeb47a7ecc834ae21140f02c60297  min_size.gif
 c6a8e6f6d6d0c969cb300ea7eb18391d  noise256.gif
 7de24bdbff1dec81aab1840bcf69b19f  noise6.gif
 a7c04cb7b6d19a16023497da03384408  only_local_table.gif


### PR DESCRIPTION
Encoding huge GIF frames might lead to a crash.
This issue is caused by default `signed int` promotion on multiply operations.
Fix this by explicitly casting to `uint32_t`

**Affected images:**
Depends on `INT_MAX`. Usually all frames with more than 2.1 billion pixels (e.g. _65535_ x _65535_)

**ToDo:**
- [x] backport fix to V0.0 branch and release V0.0.3

