### PR TITLE
Improve error handling

### DIFF
--- a/cgif.h
+++ b/cgif.h
@@ -19,6 +19,18 @@ extern "C" {
 
 #define CGIF_INFINITE_LOOP               (0x0000uL)       // for animated GIF: 0 specifies infinite loop
 
+typedef enum {
+  CGIF_ERROR = -1, // something unspecified failed
+  CGIF_OK    =  0, // everything OK
+  CGIF_EWRITE,     // writing GIF data failed
+  CGIF_EALLOC,     // allocating memory failed
+  CGIF_ECLOSE,     // final call to fclose failed
+  CGIF_EOPEN,      // failed to open output file
+  CGIF_EINDEX,     // invalid index in image data provided by user
+  // internal section (values subject to change)
+  CGIF_PENDING,
+} cgif_result;
+
 typedef struct st_gif         CGIF;                      // struct for the full GIF
 typedef struct st_frame       CGIF_Frame;                // struct for a single frame
 typedef struct st_gifconfig    CGIF_Config;                // global cofinguration parameters of the GIF
@@ -87,6 +99,7 @@ struct st_gif {
   uint8_t      aAppExt[19];                              //
   CGIF_Frame*  pCurFrame;                                // (internal) pointer to current frame
   CGIF_Frame   firstFrame;                                // (internal) pointer to next frame
+  cgif_result  curResult;
 };
 
 #ifdef __cplusplus

--- a/cgif_example.c
+++ b/cgif_example.c
@@ -30,16 +30,11 @@ int main(void) {
   uint8_t       aPalette[] = {0xFF, 0x00, 0x00,                 // red
                               0x00, 0xFF, 0x00,                 // green
                               0x00, 0x00, 0xFF};                // blue
-  cgif_result r;
   uint16_t numColors = 3;                                        // number of colors in aPalette (up to 256 possible)
 
   // initialize the GIF-configuration and create a new GIF
   initGIFConfig(&gConfig, "example_cgif.gif", WIDTH, HEIGHT, aPalette, numColors);
   pGIF = cgif_newgif(&gConfig);
-  if(pGIF == NULL) {
-    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
-    return 1;
-  }
 
   // create image frame with stripe pattern
   pImageData = malloc(WIDTH * HEIGHT);                          // allocate memory for image data
@@ -48,17 +43,11 @@ int main(void) {
   }
 
   // add frame to GIF
-  initFrameConfig(&fConfig, pImageData); // initialize the frame-configuration
-  r = cgif_addframe(pGIF, &fConfig);     // add a new frame to the GIF
-  free(pImageData);                      // free image data when frame is added
+  initFrameConfig(&fConfig, pImageData);                         // initialize the frame-configuration
+  cgif_addframe(pGIF, &fConfig);                                 // add a new frame to the GIF
+  free(pImageData);                                              // free image data when frame is added
 
   // close GIF and free allocated space
-  r = cgif_close(pGIF);
-
-  // check for errors
-  if(r != CGIF_OK) {
-    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
-    return 2;
-  }
+  cgif_close(pGIF);
   return 0;
 }

--- a/cgif_example.c
+++ b/cgif_example.c
@@ -30,11 +30,16 @@ int main(void) {
   uint8_t       aPalette[] = {0xFF, 0x00, 0x00,                 // red
                               0x00, 0xFF, 0x00,                 // green
                               0x00, 0x00, 0xFF};                // blue
-  uint8_t numColors = 3;                                        // number of colors in aPalette (up to 256 possible)   
+  cgif_result r;
+  uint16_t numColors = 3;                                        // number of colors in aPalette (up to 256 possible)
 
   // initialize the GIF-configuration and create a new GIF
   initGIFConfig(&gConfig, "example_cgif.gif", WIDTH, HEIGHT, aPalette, numColors);
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
 
   // create image frame with stripe pattern
   pImageData = malloc(WIDTH * HEIGHT);                          // allocate memory for image data
@@ -43,11 +48,17 @@ int main(void) {
   }
 
   // add frame to GIF
-  initFrameConfig(&fConfig, pImageData);                         // initialize the frame-configuration
-  cgif_addframe(pGIF, &fConfig);                                 // add a new frame to the GIF
-  free(pImageData);                                              // free image data when frame is added
+  initFrameConfig(&fConfig, pImageData); // initialize the frame-configuration
+  r = cgif_addframe(pGIF, &fConfig);     // add a new frame to the GIF
+  free(pImageData);                      // free image data when frame is added
 
   // close GIF and free allocated space
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/cgif_example_video.c
+++ b/cgif_example_video.c
@@ -32,17 +32,12 @@ int main(void) {
   uint8_t aPalette[] = {0xFF, 0x00, 0x00,                                // red
                         0x00, 0xFF, 0x00,                                // green
                         0x00, 0x00, 0xFF};                               // blue
-  cgif_result r;
   uint16_t numColors = 3;                                                // number of colors in aPalette (up to 256 possible)
   int numFrames = 12;                                                    // number of frames in the video
 
   // initialize the GIF-configuration and create a new GIF
   initGIFConfig(&gConfig, "example_video_cgif.gif", WIDTH, HEIGHT, aPalette, numColors);
   pGIF = cgif_newgif(&gConfig);
-  if(pGIF == NULL) {
-    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
-    return 1;
-  }
 
   // create image frames and add them to GIF
   pImageData = malloc(WIDTH * HEIGHT);                                   // allocate memory for image data
@@ -51,20 +46,11 @@ int main(void) {
       pImageData[i] = (unsigned char)((f + i % WIDTH ) / 4 % numColors); // moving stripe pattern (4 pixels per stripe)
     }
     initFrameConfig(&fConfig, pImageData, 10);                           // initialize the frame-configuration
-    r = cgif_addframe(pGIF, &fConfig);                                       // append the new frame
-    if(r != CGIF_OK) {
-      break; // error: cgif_addframe() failed
-    }
+    cgif_addframe(pGIF, &fConfig);                                       // append the new frame
   }
   free(pImageData);                                                      // free image data when all frames are added
 
   // close created GIF-file and free allocated space
-  r = cgif_close(pGIF);
-
-  // check for errors
-  if(r != CGIF_OK) {
-    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
-    return 2;
-  }
+  cgif_close(pGIF);
   return 0;
 }

--- a/tests/all_optim.c
+++ b/tests/all_optim.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -34,12 +35,17 @@ int main(void) {
     0x00, 0x00, 0x00, // black
     0xFF, 0xFF, 0xFF, // white
   };
+  cgif_result r;
   uint8_t numColors = 2;   // number of colors in aPalette
   int numFrames     = 2;      // number of frames in the video
   //
   // create new GIF
   initGIFConfig(&gConfig, aPalette, numColors, CGIF_ATTR_IS_ANIMATED, WIDTH, HEIGHT);
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);         // Actual image data
@@ -53,11 +59,17 @@ int main(void) {
   memset(pImageData + 7 + WIDTH * 3, 1, 41);
   memset(pImageData + 7 + WIDTH * 3, 0, 23);
   memset(pImageData + 7 + WIDTH * 4, 0, 37);
-  cgif_addframe(pGIF, &fConfig); // append the next frame
+  r = cgif_addframe(pGIF, &fConfig); // append the next frame
   //
   free(pImageData);
   //
   // Free allocated space at the end of the session
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/animated_color_gradient.c
+++ b/tests/animated_color_gradient.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -14,6 +15,7 @@ int main(void) {
   CGIF_FrameConfig  fConfig;
   uint8_t*          pImageData;
   uint8_t           aPalette[3*WIDTH];
+  cgif_result       r;
   // define red color gradient
   for (int j = 0; j < WIDTH; ++j) {
     aPalette[j*3] = j;
@@ -43,6 +45,10 @@ int main(void) {
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);         // actual image data
@@ -53,11 +59,20 @@ int main(void) {
     for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
     	pImageData[i] = (unsigned char)((i + f) % WIDTH); // ceate a moving stripe pattern
     }
-    cgif_addframe(pGIF, &fConfig);             // append the new frame
+    r = cgif_addframe(pGIF, &fConfig);             // append the new frame
+    if(r != CGIF_OK) {
+      break;
+    }
   }
   free(pImageData);
   //
   // write GIF to file
-  cgif_close(pGIF);                            // free allocated space at the end of the session
+  r = cgif_close(pGIF); // free allocated space at the end of the session
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/animated_single_pixel.c
+++ b/tests/animated_single_pixel.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -34,13 +35,17 @@ int main(void) {
   uint8_t aPalette[] = {0xFF, 0x00, 0x00,                                // red
                         0x00, 0xFF, 0x00,                                // green
                         0x00, 0x00, 0xFF};                               // blue
+  cgif_result r;
   uint8_t numColors = 3;                                                 // number of colors in aPalette (up to 256 possible)
   int numFrames = 39*4;                                                  // number of frames in the video
 
   // initialize the GIF-configuration and create a new GIF
   initGIFConfig(&gConfig, "animated_single_pixel.gif", WIDTH, HEIGHT, aPalette, numColors);
   pGIF = cgif_newgif(&gConfig);
-
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   // create image frames and add them to GIF
   pImageData = malloc(WIDTH * HEIGHT);                                   // allocate memory for image data
   memset(pImageData, 0, WIDTH * HEIGHT);                                 // set everything to the first color
@@ -59,11 +64,20 @@ int main(void) {
     }
     pImageData[x + y*WIDTH] = 1;                                         // set color of next pixel to green
     initFrameConfig(&fConfig, pImageData, 5);                            // initialize the frame-configuration
-    cgif_addframe(pGIF, &fConfig);                                       // append the new frame
+    r = cgif_addframe(pGIF, &fConfig);                                   // append the new frame
+    if(r != CGIF_OK) {
+      break;
+    }
   }
   free(pImageData);                                                      // free image data when all frames are added
 
   // close created GIF-file and free allocated space
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/animated_snake.c
+++ b/tests/animated_snake.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -31,6 +32,7 @@ int main(void) {
   CGIF_FrameConfig  fConfig;                                                  // configuration parameters for a frame
   uint8_t*    pImageData;                                                // image data (an array of color-indices)
   int x,y,x1,y1;                                                         // position of snake beginning and end
+  cgif_result r;
   uint8_t aPalette[] = {0xFF, 0x00, 0x00,                                // red
                         0x00, 0xFF, 0x00,                                // green
                         0x00, 0x00, 0xFF};                               // blue
@@ -40,6 +42,10 @@ int main(void) {
   // initialize the GIF-configuration and create a new GIF
   initGIFConfig(&gConfig, "animated_snake.gif", WIDTH, HEIGHT, aPalette, numColors);
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
 
   // create image frames and add them to GIF
   pImageData = malloc(WIDTH * HEIGHT);                                   // allocate memory for image data
@@ -73,11 +79,20 @@ int main(void) {
       x1--;
     }
     initFrameConfig(&fConfig, pImageData, 5);                            // initialize the frame-configuration
-    cgif_addframe(pGIF, &fConfig);                                       // append the new frame
+    r = cgif_addframe(pGIF, &fConfig);                                   // append the new frame
+    if(r != CGIF_OK) {
+      break;
+    }
   }
   free(pImageData);                                                      // free image data when all frames are added
 
   // close created GIF-file and free allocated space
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/animated_stripe_pattern.c
+++ b/tests/animated_stripe_pattern.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -20,6 +21,7 @@ int main(void) {
     0x00, 0xFF, 0x00, // green
     0x00, 0x00, 0xFF, // blue
   };
+  cgif_result r;
   uint8_t numColors   = 5;  // number of colors in aPalette
   int numFrames       = 30; // number of frames in the video
   
@@ -34,6 +36,10 @@ int main(void) {
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);         // actual image data
@@ -44,11 +50,20 @@ int main(void) {
     for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
     	pImageData[i] = (unsigned char)((f + i % WIDTH) % numColors); // ceate a moving stripe pattern
     }
-    cgif_addframe(pGIF, &fConfig); // append the new frame
+    r = cgif_addframe(pGIF, &fConfig); // append the new frame
+    if(r != CGIF_OK) {
+      break;
+    }
   }
   free(pImageData);
   //
   // write GIF to file
-  cgif_close(pGIF);                  // free allocated space at the end of the session
+  r = cgif_close(pGIF);                  // free allocated space at the end of the session
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/animated_stripe_pattern_2.c
+++ b/tests/animated_stripe_pattern_2.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -33,13 +34,17 @@ int main(void) {
   uint8_t aPalette[] = {0xFF, 0x00, 0x00,                                // red
                         0x00, 0xFF, 0x00,                                // green
                         0x00, 0x00, 0xFF};                               // blue
+  cgif_result r;
   uint8_t numColors = 3;                                                 // number of colors in aPalette (up to 256 possible)
   int numFrames = 24;                                                    // number of frames in the video
 
   // initialize the GIF-configuration and create a new GIF
   initGIFConfig(&gConfig, "animated_stripe_pattern_2.gif", WIDTH, HEIGHT, aPalette, numColors);
   pGIF = cgif_newgif(&gConfig);
-
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   // create image frames and add them to GIF
   pImageData = malloc(WIDTH * HEIGHT);                                   // allocate memory for image data
   memset(pImageData, 0, WIDTH * HEIGHT);                                 // set everything to 1st color in the palette
@@ -48,11 +53,19 @@ int main(void) {
       pImageData[i] = (unsigned char)((f + i % WIDTH ) / 8 % numColors); // moving stripe pattern (4 pixels per stripe)
     }
     initFrameConfig(&fConfig, pImageData, 10);                           // initialize the frame-configuration
-    cgif_addframe(pGIF, &fConfig);                                       // append the new frame
+    r = cgif_addframe(pGIF, &fConfig);                                   // append the new frame
+    if(r != CGIF_OK) {
+      break;
+    }
   }
   free(pImageData);                                                      // free image data when all frames are added
 
   // close created GIF-file and free allocated space
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/animated_stripes_horizontal.c
+++ b/tests/animated_stripes_horizontal.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -25,6 +26,7 @@ int main(void) {
     0x77, 0x00, 0x00,
     0x66, 0x00, 0x00,
   };
+  cgif_result r;
   uint8_t numColors   = 10;  // number of colors in aPalette
   int numFrames       = 10; // number of frames in the video
   
@@ -39,6 +41,10 @@ int main(void) {
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);         // actual image data
@@ -49,11 +55,17 @@ int main(void) {
     for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
     	pImageData[i] = (unsigned char)((f + numColors * i / WIDTH / HEIGHT) % numColors); // ceate a moving stripe pattern
     }
-    cgif_addframe(pGIF, &fConfig); // append the new frame
+    r = cgif_addframe(pGIF, &fConfig); // append the new frame
   }
   free(pImageData);
   //
   // write GIF to file
-  cgif_close(pGIF);                  // free allocated space at the end of the session
+  r = cgif_close(pGIF); // free allocated space at the end of the session
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/eindex.c
+++ b/tests/eindex.c
@@ -1,0 +1,63 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "cgif.h"
+
+#define WIDTH  100
+#define HEIGHT 100
+
+static int pWriteFn(void* pContext, const uint8_t* pData, const size_t numBytes) {
+  (void)pContext;
+  (void)pData;
+  (void)numBytes;
+  // just ignore GIF data
+  return 0;
+}
+
+int main(void) {
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = {
+    0x00, 0x00, 0x00, // black
+    0xFF, 0xFF, 0xFF, // white
+  };
+  cgif_result r;
+
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 2;
+  gConfig.pWriteFn                = pWriteFn;
+  gConfig.pContext                = NULL;
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  memset(pImageData, 0, WIDTH * HEIGHT);
+  pImageData[2] = 32; // 32 is not a valid index in this case.
+  fConfig.pImageData = pImageData;
+  r = cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  r = cgif_close(pGIF);                  // free allocated space at the end of the session
+
+  // check for correct error: CGIF_EINDEX
+  if(r == CGIF_EINDEX) {
+    return 0;
+  }
+  fputs("CGIF_EINDEX expected as result code\n", stderr);
+  return 2;
+}

--- a/tests/ewrite.c
+++ b/tests/ewrite.c
@@ -1,0 +1,60 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "cgif.h"
+
+#define WIDTH  100
+#define HEIGHT 100
+
+static int pWriteFn(void* pContext, const uint8_t* pData, const size_t numBytes) {
+  (void)pContext;
+  (void)pData;
+  (void)numBytes;
+  return -1; // return error code -1: should lead to EWRITE
+}
+
+int main(void) {
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = {
+    0x00, 0x00, 0x00, // black
+    0xFF, 0xFF, 0xFF, // white
+  };
+  cgif_result r;
+
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 2;
+  gConfig.pWriteFn                = pWriteFn;
+  gConfig.pContext                = NULL;
+  //
+  // create new GIF (might call pWriteFn as well)
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    return 0;
+  }
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  memset(pImageData, 0, WIDTH * HEIGHT);
+  fConfig.pImageData = pImageData;
+  r = cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  r = cgif_close(pGIF);                  // free allocated space at the end of the session
+
+  // check for errors
+  if(r == CGIF_EWRITE) {
+    return 0;
+  }
+  fputs("CGIF_EWRITE expected as result code\n", stderr);
+  return 1;
+}

--- a/tests/global_plus_local_table.c
+++ b/tests/global_plus_local_table.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -23,6 +24,7 @@ int main(void) {
     0x00, 0x00, 0xFF, // blue
     0xFF, 0x00, 0x00, // red
   };
+  cgif_result r;
   uint8_t numColorsLocal = 2;   // number of colors in aPalette
   uint8_t numColorsGlobal = 3;   // number of colors in aPalette
   //
@@ -37,6 +39,10 @@ int main(void) {
   gConfig.height                  = HEIGHT;
   gConfig.path                    = "global_plus_local_table.gif";
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // Add frame to GIF
   //
@@ -48,18 +54,24 @@ int main(void) {
   fConfig.numLocalPaletteEntries = numColorsLocal;
   fConfig.attrFlags = CGIF_FRAME_ATTR_USE_LOCAL_TABLE;
   fConfig.delay = 100;
-  cgif_addframe(pGIF, &fConfig); // append the new frame
+  r = cgif_addframe(pGIF, &fConfig); // append the new frame
   //
   // add next frame
   fConfig.attrFlags = 0;
   fConfig.genFlags = 0;
   memset(pImageData + WIDTH * 9, 2, WIDTH * 10);
-  cgif_addframe(pGIF, &fConfig); // append the new frame
+  r = cgif_addframe(pGIF, &fConfig); // append the new frame
   //
   free(pImageData);
   //
   // Free allocated space at the end of the session
   //
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/has_transparency.c
+++ b/tests/has_transparency.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -16,6 +17,7 @@ int main(void) {
     0x00, 0x00, 0x00, // black (transparent)
     0xFF, 0xFF, 0xFF, // white
   };
+  cgif_result r;
 
   memset(&gConfig, 0, sizeof(CGIF_Config));
   memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
@@ -28,6 +30,10 @@ int main(void) {
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);
@@ -43,10 +49,16 @@ int main(void) {
   for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
     pImageData[i] = 1 - (i % 2);
   }
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(pImageData);
   //
   // write GIF to file
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/has_transparency_2.c
+++ b/tests/has_transparency_2.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -16,6 +17,7 @@ int main(void) {
     0x00, 0x00, 0x00, // black (transparent)
     0xFF, 0xFF, 0xFF, // white
   };
+  cgif_result r;
 
   memset(&gConfig, 0, sizeof(CGIF_Config));
   memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
@@ -28,6 +30,10 @@ int main(void) {
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);
@@ -38,15 +44,21 @@ int main(void) {
   for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
     pImageData[i] = (i/10) % 2;
   }
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   // create opposite pattern
   for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
     pImageData[i] = 1 - ((i/10) % 2);
   }
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(pImageData);
   //
   // write GIF to file
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/max_color_table_test.c
+++ b/tests/max_color_table_test.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -14,6 +15,7 @@ int main(void) {
   CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t*      aPalette;
+  cgif_result   r;
   uint16_t      numColors         = 256; // number of colors in aPalette  
   //
   // create an image
@@ -29,16 +31,26 @@ int main(void) {
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
   gConfig.path                    = "max_color_table_test.gif";
-  pGIF = cgif_newgif(&gConfig);  
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
   fConfig.pImageData = pImageData;
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(pImageData);  
   free(aPalette);
   //
   // free allocated space at the end of the session
-  cgif_close(pGIF);  
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/max_size.c
+++ b/tests/max_size.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -14,6 +15,7 @@ int main(void) {
   CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t       aPalette[] = { 0xFF, 0x00, 0x00 };
+  cgif_result   r;
   uint16_t      numColors  = 1; // number of colors in aPalette  
   //
   // create an image
@@ -27,15 +29,25 @@ int main(void) {
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
   gConfig.path                    = "max_size.gif";
-  pGIF = cgif_newgif(&gConfig);  
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
   fConfig.pImageData = pImageData;
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(pImageData);  
   //
   // free allocated space at the end of the session
-  cgif_close(pGIF);  
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,6 +6,8 @@ tests = [
   'animated_stripes_horizontal',
   'animated_stripe_pattern',
   'animated_stripe_pattern_2',
+  'eindex',
+  'ewrite',
   'global_plus_local_table',
   'global_plus_local_table_with_optim',
   'has_transparency',

--- a/tests/min_color_table_test.c
+++ b/tests/min_color_table_test.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -14,6 +15,7 @@ int main(void) {
   CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t       aPalette[] = { 0x00, 0xFF, 0x00 }; // green
+  cgif_result   r;
   uint8_t       numColors  = 1; // number of colors in aPalette  
   //
   // create an image with all green pixels
@@ -27,15 +29,25 @@ int main(void) {
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
   gConfig.path                    = "min_color_table_test.gif";
-  pGIF = cgif_newgif(&gConfig);  
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
   fConfig.pImageData = pImageData;
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(pImageData);  
   //
   // free allocated space at the end of the session
-  cgif_close(pGIF);  
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/min_size.c
+++ b/tests/min_size.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -14,6 +15,7 @@ int main(void) {
   CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
   uint8_t       aPalette[] = { 0xFF, 0x00, 0x00 };
+  cgif_result   r;
   uint16_t      numColors  = 1; // number of colors in aPalette  
   //
   // create an image
@@ -27,15 +29,25 @@ int main(void) {
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
   gConfig.path                    = "min_size.gif";
-  pGIF = cgif_newgif(&gConfig);  
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
   fConfig.pImageData = pImageData;
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(pImageData);  
   //
   // free allocated space at the end of the session
-  cgif_close(pGIF);  
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/noise256.c
+++ b/tests/noise256.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -20,6 +21,7 @@ int main(void) {
   CGIF_Config     gConfig;
   CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
+  cgif_result   r;
   uint8_t       aPalette[256 * 3]; 
 
   seed = 22;
@@ -38,15 +40,25 @@ int main(void) {
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);
   for(int i = 0; i < WIDTH * HEIGHT; ++i) pImageData[i] = psdrand() % 256;
   fConfig.pImageData = pImageData;
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(pImageData);
   //
   // write GIF to file
-  cgif_close(pGIF); // free allocated space at the end of the session
+  r = cgif_close(pGIF); // free allocated space at the end of the session
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/noise6.c
+++ b/tests/noise6.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -20,6 +21,7 @@ int main(void) {
   CGIF_Config     gConfig;
   CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
+  cgif_result   r;
   uint8_t       aPalette[6 * 3]; 
 
   seed = 42;
@@ -38,15 +40,25 @@ int main(void) {
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);
   for(int i = 0; i < WIDTH * HEIGHT; ++i) pImageData[i] = psdrand() % 6;
   fConfig.pImageData = pImageData;
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(pImageData);
   //
   // write GIF to file
-  cgif_close(pGIF); // free allocated space at the end of the session
+  r = cgif_close(pGIF); // free allocated space at the end of the session
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/one_full_block.c
+++ b/tests/one_full_block.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -13,7 +14,8 @@ int main(void) {
   CGIF_Config     gConfig;
   CGIF_FrameConfig   fConfig;
   uint8_t*      pImageData;
-  uint8_t*      aPalette = malloc(3 * HEIGHT); 
+  uint8_t*      aPalette = malloc(3 * HEIGHT);
+  cgif_result   r;
   uint16_t      numColors  = HEIGHT; // number of colors in aPalette  
   
   memset(aPalette, 0, 3 * HEIGHT);
@@ -29,16 +31,26 @@ int main(void) {
   gConfig.pGlobalPalette          = aPalette;
   gConfig.numGlobalPaletteEntries = numColors;
   gConfig.path                    = "one_full_block.gif";
-  pGIF = cgif_newgif(&gConfig);  
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
   fConfig.pImageData = pImageData;
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(aPalette);
   free(pImageData);  
   //
   // free allocated space at the end of the session
-  cgif_close(pGIF);  
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/only_local_table.c
+++ b/tests/only_local_table.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -18,6 +19,7 @@ int main(void) {
     0x00, 0x00, 0x00, // black
     0xFF, 0xFF, 0xFF, // white
   };
+  cgif_result r;
   uint8_t numColors = 2;   // number of colors in aPalette
   //
   // Create new GIF
@@ -29,6 +31,10 @@ int main(void) {
   gConfig.height                  = HEIGHT;
   gConfig.path                    = "only_local_table.gif";
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // Add frame to GIF
   //
@@ -39,12 +45,18 @@ int main(void) {
   fConfig.pLocalPalette = aPalette;
   fConfig.numLocalPaletteEntries = numColors;
   fConfig.attrFlags = CGIF_FRAME_ATTR_USE_LOCAL_TABLE;
-  cgif_addframe(pGIF, &fConfig); // append the new frame
+  r = cgif_addframe(pGIF, &fConfig); // append the new frame
   //
   free(pImageData);
   //
   // Free allocated space at the end of the session
   //
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/overlap_everything.c
+++ b/tests/overlap_everything.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -19,6 +20,7 @@ int main(void) {
     0xFF, 0xFF, 0xFF, // white
   };
   uint8_t numColors = 2;   // number of colors in aPalette
+  cgif_result r;
   int numFrames = 2;      // number of frames in the video
   //
   // Create new GIF
@@ -32,6 +34,10 @@ int main(void) {
   gConfig.numGlobalPaletteEntries = numColors;
   gConfig.path                    = "overlap_everything.gif";
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // Add frames to GIF
   //
@@ -40,12 +46,18 @@ int main(void) {
   fConfig.pImageData = pImageData;
   fConfig.delay      = 100;  // set time before next frame (in units of 0.01 s)
   fConfig.genFlags   = CGIF_FRAME_GEN_USE_DIFF_WINDOW;
-  cgif_addframe(pGIF, &fConfig); // append the new frame
-  cgif_addframe(pGIF, &fConfig); // append the next frame
+  r = cgif_addframe(pGIF, &fConfig); // append the new frame
+  r = cgif_addframe(pGIF, &fConfig); // append the next frame
   //
   free(pImageData);
   //
   // free allocated space at the end of the session
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/overlap_everything_only_trans.c
+++ b/tests/overlap_everything_only_trans.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -19,6 +20,7 @@ int main(void) {
     0xFF, 0xFF, 0xFF, // white
   };
   uint8_t numColors = 2;   // number of colors in aPalette
+  cgif_result r;
   int numFrames = 2;      // number of frames in the video
   //
   // Create new GIF
@@ -32,6 +34,10 @@ int main(void) {
   gConfig.numGlobalPaletteEntries = numColors;
   gConfig.path                    = "overlap_everything_only_trans.gif";
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // Add frames to GIF
   //
@@ -40,12 +46,18 @@ int main(void) {
   fConfig.pImageData = pImageData;
   fConfig.delay      = 100;  // set time before next frame (in units of 0.01 s)
   fConfig.genFlags   = CGIF_FRAME_GEN_USE_TRANSPARENCY;
-  cgif_addframe(pGIF, &fConfig); // append the new frame
-  cgif_addframe(pGIF, &fConfig); // append the next frame
+  r = cgif_addframe(pGIF, &fConfig); // append the new frame
+  r = cgif_addframe(pGIF, &fConfig); // append the next frame
   //
   free(pImageData);
   //
   // free allocated space at the end of the session
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/overlap_some_rows.c
+++ b/tests/overlap_some_rows.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -19,6 +20,7 @@ int main(void) {
     0xFF, 0xFF, 0xFF, // white
   };
   uint8_t numColors = 2;   // number of colors in aPalette
+  cgif_result r;
   int numFrames = 2;      // number of frames in the video
   //
   // Create new GIF
@@ -32,6 +34,10 @@ int main(void) {
   gConfig.numGlobalPaletteEntries = numColors;
   gConfig.path                    = "overlap_some_rows.gif";
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // Add frames to GIF
   //
@@ -40,17 +46,23 @@ int main(void) {
   fConfig.pImageData = pImageData;
   fConfig.delay      = 100;  // set time before next frame (in units of 0.01 s)
   fConfig.genFlags   = CGIF_FRAME_GEN_USE_DIFF_WINDOW;
-  cgif_addframe(pGIF, &fConfig); // append the new frame
+  r = cgif_addframe(pGIF, &fConfig); // append the new frame
   memset(pImageData + 7, 1, 55);
   memset(pImageData + 7 + WIDTH, 1, 55);
   memset(pImageData + 7 + WIDTH * 2, 1, 55);
   memset(pImageData + 7 + WIDTH * 3, 1, 55);
-  cgif_addframe(pGIF, &fConfig); // append the next frame
+  r = cgif_addframe(pGIF, &fConfig); // append the next frame
   //
   free(pImageData);
   //
   // Free allocated space at the end of the session
   //
-  cgif_close(pGIF);
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/trans_inc_initdict.c
+++ b/tests/trans_inc_initdict.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -19,6 +20,7 @@ int main(void) {
     0xFF, 0x00, 0x00, // red
     0x00, 0xFF, 0x00, // green
   };
+  cgif_result r;
   uint8_t numColors   = 4;  // number of colors in aPalette
   int numFrames       = 30; // number of frames in the video
   
@@ -33,6 +35,10 @@ int main(void) {
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);         // actual image data
@@ -41,13 +47,22 @@ int main(void) {
   fConfig.delay      = 10;                     // set time before next frame (in units of 0.01 s)
   for (int f = 0; f < numFrames; ++f) {
     for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
-    	pImageData[i] = (unsigned char)((f + i % WIDTH) % numColors); // ceate a moving stripe pattern
+      pImageData[i] = (unsigned char)((f + i % WIDTH) % numColors); // ceate a moving stripe pattern
     }
-    cgif_addframe(pGIF, &fConfig); // append the new frame
+    r = cgif_addframe(pGIF, &fConfig); // append the new frame
+    if(r != CGIF_OK) {
+      break;
+    }
   }
   free(pImageData);
   //
   // write GIF to file
-  cgif_close(pGIF);                  // free allocated space at the end of the session
+  r = cgif_close(pGIF);                  // free allocated space at the end of the session
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }

--- a/tests/write_fn.c
+++ b/tests/write_fn.c
@@ -8,7 +8,12 @@
 #define HEIGHT 100
 
 static int pWriteFn(void* pContext, const uint8_t* pData, const size_t numBytes) {
-  return fwrite(pData, 1, numBytes, (FILE*) pContext);
+  size_t r = fwrite(pData, 1, numBytes, (FILE*) pContext);
+  if(r == numBytes) {
+    return 0;
+  } else {
+    return -1;
+  }
 }
 
 int main(void) {

--- a/tests/write_fn.c
+++ b/tests/write_fn.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "cgif.h"
 
@@ -25,6 +26,7 @@ int main(void) {
     0x00, 0x00, 0x00, // black
     0xFF, 0xFF, 0xFF, // white
   };
+  cgif_result r;
 
   FILE* file = fopen("write_fn.gif", "wb");
 
@@ -39,16 +41,26 @@ int main(void) {
   //
   // create new GIF
   pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
   //
   // add frames to GIF
   pImageData = malloc(WIDTH * HEIGHT);
   memset(pImageData, 0, WIDTH * HEIGHT);
   fConfig.pImageData = pImageData;
-  cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
   free(pImageData);
   //
   // write GIF to file
-  cgif_close(pGIF);                  // free allocated space at the end of the session
+  r = cgif_close(pGIF);                  // free allocated space at the end of the session
   fclose(file);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
   return 0;
 }


### PR DESCRIPTION
Improve error handling of cgif by introducing certain public result codes (e.g. `CGIF_OK`, `CGIF_EINDEX`, etc.).
For more details please have a look into `cgif.h`.

- [x] Make use of the result codes in all examples and tests.
- [x] Update documentation (README + Wiki).
- [x] Create coverage tests for error cases.