### PR TITLE
Fix: Transparency optimization could have been used for local tables with 256 entries

### DIFF
--- a/tests/local_transp.c
+++ b/tests/local_transp.c
@@ -1,0 +1,64 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <time.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "cgif.h"
+
+#define WIDTH  103
+#define HEIGHT 104
+
+/* This is an example code that creates a GIF-animation with a moving stripe-pattern. */
+int main(void) {
+  CGIF*         pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t aPalette[3 * 256] = {
+    0x00, 0x00, 0x00, // black
+    0xFF, 0xFF, 0xFF, // white
+  };
+  cgif_result r;
+  uint16_t numColors = 256;   // number of colors in aPalette
+  //
+  // Create new GIF
+  //
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_NO_GLOBAL_TABLE | CGIF_ATTR_IS_ANIMATED;
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.path                    = "local_transp.gif";
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
+  //
+  // Add frame to GIF
+  //
+  pImageData = malloc(WIDTH * HEIGHT);         // Actual image data
+  memset(pImageData, 1, WIDTH * HEIGHT);
+  memset(pImageData + WIDTH * 2, 0, WIDTH * 3);
+  fConfig.pImageData = pImageData;
+  fConfig.pLocalPalette = aPalette;
+  fConfig.numLocalPaletteEntries = numColors;
+  fConfig.attrFlags = CGIF_FRAME_ATTR_USE_LOCAL_TABLE;
+  fConfig.genFlags = CGIF_FRAME_GEN_USE_TRANSPARENCY;
+  r = cgif_addframe(pGIF, &fConfig); // append the new frame
+  r = cgif_addframe(pGIF, &fConfig); // append the new frame
+  //
+  free(pImageData);
+  //
+  // Free allocated space at the end of the session
+  //
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
+  return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,6 +12,7 @@ tests = [
   'global_plus_local_table_with_optim',
   'has_transparency',
   'has_transparency_2',
+  'local_transp',
   'max_color_table_test',
   'min_color_table_test',
   'min_size',

--- a/tests/tests.md5
+++ b/tests/tests.md5
@@ -9,6 +9,7 @@ a8c2e6153396de90eaa1947178b1e383  animated_stripe_pattern.gif
 11b1703658c920b6f86d32827291dde4  global_plus_local_table_with_optim.gif
 3eda7f993b36270db09929a289a5a106  has_transparency_2.gif
 c8bc7f745090e5f386e2c69f697c1343  has_transparency.gif
+b702bac8f8ded19ec1f58c1f80ee9208  local_transp.gif
 8c0e65694eef4f3ed986381cfe914b50  max_color_table_test.gif
 # too large for CI: dd8cb01f5b02c16cc346b51d1faadc63  max_size.gif
 30ab701c8e56bc8b09c824305002de5a  min_color_table_test.gif


### PR DESCRIPTION
Transparency optimization is not possible for frames with exactly 256 colors in the color table, as there is not free index for transparency. Add a check for local color tables as well.

**ToDo:**
- [x] Add test