### PR TITLE
Allow user to set per-frame alpha channel and transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ With our encoder you can create animated or static GIFs, you can or cannot use c
 ```C
 CGIF_ATTR_IS_ANIMATED              // make an animated GIF (default is non-animated GIF)
 CGIF_ATTR_NO_GLOBAL_TABLE          // disable global color table (global color table is default)
-CGIF_ATTR_HAS_TRANSPARENCY         // first entry in color table contains transparency
+CGIF_ATTR_HAS_TRANSPARENCY         // first entry in color table contains transparency (alpha channel)
 CGIF_FRAME_ATTR_USE_LOCAL_TABLE    // use a local color table for a frame (not used by default)
+CGIF_FRAME_ATTR_HAS_ALPHA          // frame contains alpha channel (index set via transIndex field)
+CGIF_FRAME_ATTR_HAS_SET_TRANS      // transparency setting provided by user (transIndex field)
 CGIF_FRAME_GEN_USE_TRANSPARENCY    // use transparency optimization (size optimization)
 CGIF_FRAME_GEN_USE_DIFF_WINDOW     // do encoding just for the sub-window that changed (size optimization)
 ```

--- a/inc/cgif.h
+++ b/inc/cgif.h
@@ -11,8 +11,10 @@ extern "C" {
 // flags to set the GIF/frame-attributes
 #define CGIF_ATTR_IS_ANIMATED            (1uL << 1)       // make an animated GIF (default is non-animated GIF)
 #define CGIF_ATTR_NO_GLOBAL_TABLE        (1uL << 2)       // disable global color table (global color table is default)
-#define CGIF_ATTR_HAS_TRANSPARENCY       (1uL << 3)       // first entry in color table contains transparency
+#define CGIF_ATTR_HAS_TRANSPARENCY       (1uL << 3)       // first entry in color table contains transparency (alpha channel)
 #define CGIF_FRAME_ATTR_USE_LOCAL_TABLE  (1uL << 0)       // use a local color table for a frame (local color table is not used by default)
+#define CGIF_FRAME_ATTR_HAS_ALPHA        (1uL << 1)       // alpha channel index provided by user (transIndex field)
+#define CGIF_FRAME_ATTR_HAS_SET_TRANS    (1uL << 2)       // transparency setting provided by user (transIndex field)
 // flags to decrease GIF-size
 #define CGIF_FRAME_GEN_USE_TRANSPARENCY  (1uL << 0)       // use transparency optimization (setting pixels identical to previous frame transparent)
 #define CGIF_FRAME_GEN_USE_DIFF_WINDOW   (1uL << 1)       // do encoding just for the sub-window that has changed from previous frame
@@ -31,9 +33,9 @@ typedef enum {
   CGIF_PENDING,
 } cgif_result;
 
-typedef struct st_gif         CGIF;                      // struct for the full GIF
-typedef struct st_gifconfig    CGIF_Config;                // global cofinguration parameters of the GIF
-typedef struct st_frameconfig  CGIF_FrameConfig;           // local configuration parameters for a frame
+typedef struct st_gif                  CGIF;              // struct for the full GIF
+typedef struct st_gifconfig            CGIF_Config;       // global cofinguration parameters of the GIF
+typedef struct st_frameconfig          CGIF_FrameConfig;  // local configuration parameters for a frame
 
 typedef int cgif_write_fn(void* pContext, const uint8_t* pData, const size_t numBytes); // callback function for stream-based output
 
@@ -66,6 +68,7 @@ struct st_frameconfig {
   uint32_t  genFlags;                                  // flags that determine how the GIF frame is created (e.g. optimization)
   uint16_t  delay;                                     // delay before the next frame is shown (units of 0.01 s)
   uint16_t  numLocalPaletteEntries;                    // size of the local color table
+  uint8_t   transIndex;                                // introduced with V0.2.0
 };
 
 #ifdef __cplusplus

--- a/src/cgif.c
+++ b/src/cgif.c
@@ -132,6 +132,9 @@ static int cmpPixel(const CGIF* pGIF, const CGIF_FrameConfig* pCur, const CGIF_F
   uint8_t* pBefCT; // color table to use for pBef
   uint8_t* pCurCT; // color table to use for pCur
 
+  if((pCur->attrFlags & CGIF_FRAME_ATTR_HAS_SET_TRANS) && iCur == pCur->transIndex) {
+    return 0; // identical
+  }
   // TBD add safety checks
   pBefCT = (pBef->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? pBef->pLocalPalette : pGIF->config.pGlobalPalette; // local or global table used?
   pCurCT = (pCur->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? pCur->pLocalPalette : pGIF->config.pGlobalPalette; // local or global table used?
@@ -235,7 +238,7 @@ static cgif_result flushFrame(CGIF* pGIF, CGIF_Frame* pCur, CGIF_Frame* pBef) {
   DimResult           dimResult;
   uint8_t*            pTmpImageData;
   uint8_t*            pBefImageData;
-  int                 isFirstFrame, useLCT, hasTrans;
+  int                 isFirstFrame, useLCT, hasAlpha, hasTrans;
   uint16_t            numPaletteEntries;
   uint16_t            imageWidth, imageHeight, width, height, top, left;
   uint8_t             transIndex, disposalMethod;
@@ -245,18 +248,24 @@ static cgif_result flushFrame(CGIF* pGIF, CGIF_Frame* pCur, CGIF_Frame* pBef) {
   imageHeight    = pGIF->config.height;
   isFirstFrame   = (pBef == NULL) ? 1 : 0;
   useLCT         = (pCur->config.attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? 1 : 0;
-  hasTrans       = (pGIF->config.attrFlags & CGIF_ATTR_HAS_TRANSPARENCY)      ? 1 : 0;
+  hasAlpha       = ((pGIF->config.attrFlags & CGIF_ATTR_HAS_TRANSPARENCY) || (pCur->config.attrFlags & CGIF_FRAME_ATTR_HAS_ALPHA)) ? 1 : 0;
+  hasTrans       = (pCur->config.attrFlags & CGIF_FRAME_ATTR_HAS_SET_TRANS) ? 1 : 0;
   disposalMethod = pCur->disposalMethod;
   transIndex     = pCur->transIndex;
   // deactivate impossible size optimizations 
-  //  => in case user-defined transparency is used
+  //  => in case alpha channel is used
   // CGIF_FRAME_GEN_USE_TRANSPARENCY and CGIF_FRAME_GEN_USE_DIFF_WINDOW are not possible
-  if(isFirstFrame || hasTrans) {
+  if(isFirstFrame || hasAlpha) {
     pCur->config.genFlags &= ~(CGIF_FRAME_GEN_USE_TRANSPARENCY | CGIF_FRAME_GEN_USE_DIFF_WINDOW);
+  }
+  // transparency setting (which areas are identical to the frame before) provided by user:
+  // CGIF_FRAME_GEN_USE_TRANSPARENCY not possible
+  if(hasTrans) {
+    pCur->config.genFlags &= ~(CGIF_FRAME_GEN_USE_TRANSPARENCY);
   }
   numPaletteEntries = (useLCT) ? pCur->config.numLocalPaletteEntries : pGIF->config.numGlobalPaletteEntries;
   // switch off transparency optimization if color table is full (no free spot for the transparent index), TBD: count used colors, adapt table
-  if(numPaletteEntries == 256){
+  if(numPaletteEntries == 256) {
     pCur->config.genFlags &= ~CGIF_FRAME_GEN_USE_TRANSPARENCY;
   }
 
@@ -302,7 +311,7 @@ static cgif_result flushFrame(CGIF* pGIF, CGIF_Frame* pCur, CGIF_Frame* pBef) {
   rawConfig.pLCT           = pCur->config.pLocalPalette;
   rawConfig.pImageData     = (pTmpImageData) ? pTmpImageData : pCur->config.pImageData;
   rawConfig.attrFlags      = 0;
-  if(hasTrans || (pCur->config.genFlags & CGIF_FRAME_GEN_USE_TRANSPARENCY)) {
+  if(hasAlpha || (pCur->config.genFlags & CGIF_FRAME_GEN_USE_TRANSPARENCY) || hasTrans) {
     rawConfig.attrFlags |= CGIF_RAW_FRAME_ATTR_HAS_TRANS;
   }
   rawConfig.width          = width;
@@ -328,14 +337,33 @@ static void freeFrame(CGIF_Frame* pFrame) {
   }
 }
 
+static void copyFrameConfig(CGIF_FrameConfig* pDest, CGIF_FrameConfig* pSrc) {
+  pDest->pLocalPalette          = pSrc->pLocalPalette; // might need a deep copy
+  pDest->pImageData             = pSrc->pImageData;    // might need a deep copy
+  pDest->attrFlags              = pSrc->attrFlags;
+  pDest->genFlags               = pSrc->genFlags;
+  pDest->delay                  = pSrc->delay;
+  pDest->numLocalPaletteEntries = pSrc->numLocalPaletteEntries;
+  // do not copy transIndex as it was introduced with V0.2.0
+}
+
 /* queue a new GIF frame */
 int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
   CGIF_Frame* pNewFrame;
+  int         hasAlpha, hasTrans;
   int         i;
   cgif_result r;
 
   // check for previous errors
   if(pGIF->curResult != CGIF_OK && pGIF->curResult != CGIF_PENDING) {
+    return pGIF->curResult;
+  }
+  hasAlpha = ((pGIF->config.attrFlags & CGIF_ATTR_HAS_TRANSPARENCY) || (pConfig->attrFlags & CGIF_FRAME_ATTR_HAS_ALPHA)) ? 1 : 0;
+  hasTrans = (pConfig->attrFlags & CGIF_FRAME_ATTR_HAS_SET_TRANS) ? 1 : 0;
+  // check for invalid config:
+  // cannot set alpha channel and user-provided transparency at the same time.
+  if(hasAlpha && hasTrans) {
+    pGIF->curResult = CGIF_ERROR;
     return pGIF->curResult;
   }
   // search for free slot in frame queue
@@ -357,8 +385,8 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
   }
   // create new Frame struct + make a deep copy of pConfig.
   pNewFrame = malloc(sizeof(CGIF_Frame));
-  memcpy(&(pNewFrame->config), pConfig, sizeof(CGIF_FrameConfig));
-  pNewFrame->config.pImageData     = malloc(MULU16(pGIF->config.width, pGIF->config.height));
+  copyFrameConfig(&(pNewFrame->config), pConfig);
+  pNewFrame->config.pImageData = malloc(MULU16(pGIF->config.width, pGIF->config.height));
   memcpy(pNewFrame->config.pImageData, pConfig->pImageData, MULU16(pGIF->config.width, pGIF->config.height));
   // make a deep copy of the local color table, if required.
   if(pConfig->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) {
@@ -376,6 +404,18 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
       pGIF->aFrames[i - 1]->config.genFlags &= ~(CGIF_FRAME_GEN_USE_TRANSPARENCY | CGIF_FRAME_GEN_USE_DIFF_WINDOW);
       pGIF->aFrames[i - 1]->disposalMethod   = DISPOSAL_METHOD_BACKGROUND; // restore to background color
     }
+  }
+  // set per-frame alpha channel (we need to adapt the disposal method of the frame before)
+  if(pConfig->attrFlags & CGIF_FRAME_ATTR_HAS_ALPHA) {
+    pGIF->aFrames[i]->transIndex = pConfig->transIndex;
+    if(pGIF->aFrames[i - 1] != NULL) {
+      pGIF->aFrames[i - 1]->config.genFlags &= ~(CGIF_FRAME_GEN_USE_TRANSPARENCY | CGIF_FRAME_GEN_USE_DIFF_WINDOW);
+      pGIF->aFrames[i - 1]->disposalMethod   = DISPOSAL_METHOD_BACKGROUND; // restore to background color
+    }
+  }
+  // user provided transparency setting
+  if(hasTrans) {
+    pGIF->aFrames[i]->transIndex = pConfig->transIndex;
   }
   pGIF->curResult = CGIF_OK;
   return pGIF->curResult;

--- a/src/cgif.c
+++ b/src/cgif.c
@@ -135,6 +135,9 @@ static int cmpPixel(const CGIF* pGIF, const CGIF_FrameConfig* pCur, const CGIF_F
   if((pCur->attrFlags & CGIF_FRAME_ATTR_HAS_SET_TRANS) && iCur == pCur->transIndex) {
     return 0; // identical
   }
+  if((pBef->attrFlags & CGIF_FRAME_ATTR_HAS_SET_TRANS) && iBef == pBef->transIndex) {
+    return 1; // done: cannot compare
+  }
   // TBD add safety checks
   pBefCT = (pBef->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? pBef->pLocalPalette : pGIF->config.pGlobalPalette; // local or global table used?
   pCurCT = (pCur->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? pCur->pLocalPalette : pGIF->config.pGlobalPalette; // local or global table used?
@@ -344,7 +347,10 @@ static void copyFrameConfig(CGIF_FrameConfig* pDest, CGIF_FrameConfig* pSrc) {
   pDest->genFlags               = pSrc->genFlags;
   pDest->delay                  = pSrc->delay;
   pDest->numLocalPaletteEntries = pSrc->numLocalPaletteEntries;
-  // do not copy transIndex as it was introduced with V0.2.0
+  // copy transIndex if necessary (field added with V0.2.0)
+  if(pSrc->attrFlags & (CGIF_FRAME_ATTR_HAS_ALPHA | CGIF_FRAME_ATTR_HAS_SET_TRANS)) {
+    pDest->transIndex = pSrc->transIndex;
+  }
 }
 
 /* queue a new GIF frame */

--- a/tests/alpha.c
+++ b/tests/alpha.c
@@ -1,0 +1,66 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "cgif.h"
+
+#define WIDTH  99
+#define HEIGHT 99
+
+int main(void) {
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = {
+    0xFF, 0x00, 0x00, // green 
+    0xFF, 0xFF, 0xFF, // white
+  };
+  cgif_result r;
+
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_IS_ANIMATED;
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 2;
+  gConfig.path                    = "alpha.gif";
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  memset(pImageData, 0, WIDTH * HEIGHT);
+  fConfig.pImageData = pImageData;
+  fConfig.delay      = 100;
+  // create an off/on pattern
+  for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
+    pImageData[i] = i % 2;
+  }
+  cgif_addframe(pGIF, &fConfig);
+  // create transparent frame (alpha channel)
+  for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
+    pImageData[i] = 2;
+  }
+  fConfig.attrFlags  = CGIF_FRAME_ATTR_HAS_ALPHA;
+  fConfig.transIndex = 2;
+  r = cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
+  return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,6 @@
 tests = [
   'all_optim',
+  'alpha',
   'animated_color_gradient',
   'animated_single_pixel',
   'animated_snake',
@@ -24,6 +25,7 @@ tests = [
   'overlap_everything_only_trans',
   'overlap_some_rows',
   'trans_inc_initdict',
+  'user_trans',
   'write_fn',
 ]
 

--- a/tests/tests.md5
+++ b/tests/tests.md5
@@ -1,4 +1,5 @@
 cffd10a00f40b7e9c4a002251e5e9b7e  all_optim.gif
+3419edce150c2f30dc3979207f0e516d  alpha.gif
 334dc7f22fb6ad225f7e6c8c164eeaab  animated_color_gradient.gif
 9996ce895768140e06941161e6fb42ee  animated_single_pixel.gif
 59234443f5b84b0332c686c3416b6a7b  animated_snake.gif
@@ -22,4 +23,5 @@ a7c04cb7b6d19a16023497da03384408  only_local_table.gif
 5a72df08de28f6a72dfed41c635db9e9  overlap_everything_only_trans.gif
 e9e789738541e15028dfe2abdbc67314  overlap_some_rows.gif
 41b1b51c1aebb0ec72b44d0d2a395d58  trans_inc_initdict.gif
+327d60a4a703fc6892061bd701ff6e58  user_trans.gif
 4c58f4fcd9dbf119385a99cdcd353114  write_fn.gif

--- a/tests/user_trans.c
+++ b/tests/user_trans.c
@@ -1,0 +1,64 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "cgif.h"
+
+#define WIDTH  100
+#define HEIGHT 100 
+
+int main(void) {
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = {
+    0x00, 0xFF, 0x00, // green 
+    0xFF, 0xFF, 0xFF, // white
+  };
+  cgif_result r;
+
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.attrFlags               = CGIF_ATTR_IS_ANIMATED;
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 2;
+  gConfig.path                    = "user_trans.gif";
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  memset(pImageData, 0, WIDTH * HEIGHT);
+  fConfig.pImageData = pImageData;
+  fConfig.delay      = 100;
+  // create an off/on pattern
+  for (int i = 0; i < (WIDTH * HEIGHT); ++i) {
+    pImageData[i] = i % 2;
+  }
+  cgif_addframe(pGIF, &fConfig);
+  // set everything to transparent (frame from before shines through)
+  memset(pImageData, 2, WIDTH * HEIGHT);
+  fConfig.attrFlags  = CGIF_FRAME_ATTR_HAS_SET_TRANS;
+  fConfig.transIndex = 2;
+  r = cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
+  return 0;
+}


### PR DESCRIPTION
Allow user to set per-frame alpha channel and transparency.
Adds the following **CGIF_FRAME_ATTR_** flags:
- **`CGIF_FRAME_ATTR_HAS_ALPHA`**
- **`CGIF_FRAME_ATTR_HAS_SET_TRANS`**

Both flags allow passing the corresponding transparency index in the new `transIndex` field (`CGIF_FrameConfig`).
With `CGIF_FRAME_ATTR_HAS_SET_TRANS` the user can mark identical areas in the frame before.
`CGIF_FRAME_ATTR_HAS_ALPHA` is similar to `CGIF_ATTR_HAS_TRANSPARENCY` just on a frame level.
