### PR TITLE
Fix potential memory leak when closing a GIF stream without frames

### DIFF
--- a/src/cgif.c
+++ b/src/cgif.c
@@ -452,14 +452,15 @@ int cgif_close(CGIF* pGIF) {
       }
     }
   }
+
+  // cleanup
+CGIF_CLOSE_Cleanup:
   r = cgif_raw_close(pGIF->pGIFRaw); // close raw GIF stream
   // check for errors
   if(r != CGIF_OK) {
     pGIF->curResult = r;
   }
 
-  // cleanup
-CGIF_CLOSE_Cleanup:
   if(pGIF->pFile) {
     r = fclose(pGIF->pFile); // we are done at this point => close the file
     if(r) {

--- a/tests/earlyclose.c
+++ b/tests/earlyclose.c
@@ -1,0 +1,55 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "cgif.h"
+
+#define WIDTH  100
+#define HEIGHT 100
+
+static int pWriteFn(void* pContext, const uint8_t* pData, const size_t numBytes) {
+  (void)pContext;
+  (void)pData;
+  (void)numBytes;
+  // just ignore GIF data
+  return 0;
+}
+
+int main(void) {
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = {
+    0x00, 0x00, 0x00, // black
+    0xFF, 0xFF, 0xFF, // white
+  };
+  cgif_result r;
+
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 2;
+  gConfig.pWriteFn                = pWriteFn;
+  gConfig.pContext                = NULL;
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
+  //
+  // close GIF without adding frames before
+  r = cgif_close(pGIF);                  // free allocated space at the end of the session
+
+  // check for correct error
+  if(r != CGIF_OK) {
+    return 0;
+  }
+  fputs("CGIF_ERROR expected as result code\n", stderr);
+  return 2;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@ tests = [
   'animated_stripes_horizontal',
   'animated_stripe_pattern',
   'animated_stripe_pattern_2',
+  'earlyclose',
   'eindex',
   'ewrite',
   'global_plus_local_table',


### PR DESCRIPTION
Fix a memory leak when closing the GIF stream with `cgif_close()` before any frame has been added.
It is necessary to call `cgif_raw_close()` in any case.
Closes #40 