### PR TITLE
Fix potential double free if a previous error occurred

### DIFF
--- a/src/cgif.c
+++ b/src/cgif.c
@@ -384,6 +384,7 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
   if(i == SIZE_FRAME_QUEUE) {
     r = flushFrame(pGIF, pGIF->aFrames[1], pGIF->aFrames[0]);
     freeFrame(pGIF->aFrames[0]);
+    pGIF->aFrames[0] = NULL;
     // check for errors
     if(r != CGIF_OK) {
       pGIF->curResult = r;

--- a/tests/eindex_anim.c
+++ b/tests/eindex_anim.c
@@ -1,0 +1,66 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "cgif.h"
+
+#define WIDTH  100
+#define HEIGHT 100
+
+static int pWriteFn(void* pContext, const uint8_t* pData, const size_t numBytes) {
+  (void)pContext;
+  (void)pData;
+  (void)numBytes;
+  // just ignore GIF data
+  return 0;
+}
+
+int main(void) {
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = {
+    0x00, 0x00, 0x00, // black
+    0xFF, 0xFF, 0xFF, // white
+  };
+  cgif_result r;
+
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 2;
+  gConfig.pWriteFn                = pWriteFn;
+  gConfig.pContext                = NULL;
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  memset(pImageData, 0, WIDTH * HEIGHT);
+  fConfig.pImageData = pImageData;
+  r = cgif_addframe(pGIF, &fConfig);
+  pImageData[2] = 32; // 32 is not a valid index in this case.
+  r = cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
+  r = cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  r = cgif_close(pGIF);                  // free allocated space at the end of the session
+
+  // check for correct error: CGIF_EINDEX
+  if(r == CGIF_EINDEX) {
+    return 0;
+  }
+  fputs("CGIF_EINDEX expected as result code\n", stderr);
+  return 2;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -9,6 +9,7 @@ tests = [
   'animated_stripe_pattern_2',
   'earlyclose',
   'eindex',
+  'eindex_anim',
   'ewrite',
   'global_plus_local_table',
   'global_plus_local_table_with_optim',


### PR DESCRIPTION
Fix potential double free in `cgif_close()` which might have occurred if we detected a previous error in `cgif_addframe()` (e.g. `CGIF_EINDEX`). A freed entry in the frame queue was not marked as freed.
Introduced by #36. Issue can be reproduced with `tests/eindex_anim.c`.