### PR TITLE
Improve sanity checks of user input

### DIFF
--- a/src/cgif.c
+++ b/src/cgif.c
@@ -138,7 +138,12 @@ static int cmpPixel(const CGIF* pGIF, const CGIF_FrameConfig* pCur, const CGIF_F
   if((pBef->attrFlags & CGIF_FRAME_ATTR_HAS_SET_TRANS) && iBef == pBef->transIndex) {
     return 1; // done: cannot compare
   }
-  // TBD add safety checks
+  // safety bounds check
+  const uint16_t sizeCTBef = (pBef->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? pBef->numLocalPaletteEntries : pGIF->config.numGlobalPaletteEntries;
+  const uint16_t sizeCTCur = (pCur->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? pCur->numLocalPaletteEntries : pGIF->config.numGlobalPaletteEntries;
+  if((iBef >= sizeCTBef) || (iCur >= sizeCTCur)) {
+    return 1; // error: out-of-bounds - cannot compare
+  }
   pBefCT = (pBef->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? pBef->pLocalPalette : pGIF->config.pGlobalPalette; // local or global table used?
   pCurCT = (pCur->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? pCur->pLocalPalette : pGIF->config.pGlobalPalette; // local or global table used?
   return memcmp(pBefCT + iBef * 3, pCurCT + iCur * 3, 3);

--- a/src/cgif.c
+++ b/src/cgif.c
@@ -260,6 +260,11 @@ static cgif_result flushFrame(CGIF* pGIF, CGIF_Frame* pCur, CGIF_Frame* pBef) {
   hasSetTransp   = (pCur->config.attrFlags & CGIF_FRAME_ATTR_HAS_SET_TRANS) ? 1 : 0;
   disposalMethod = pCur->disposalMethod;
   transIndex     = pCur->transIndex;
+  // sanity check:
+  // at least one valid CT needed (global or local)
+  if(!useLCT && (pGIF->config.attrFlags & CGIF_ATTR_NO_GLOBAL_TABLE)) {
+    return CGIF_ERROR; // invalid config
+  }
   // deactivate impossible size optimizations 
   //  => in case alpha channel is used
   // CGIF_FRAME_GEN_USE_TRANSPARENCY and CGIF_FRAME_GEN_USE_DIFF_WINDOW are not possible

--- a/src/cgif.c
+++ b/src/cgif.c
@@ -94,7 +94,7 @@ CGIF* cgif_newgif(CGIF_Config* pConfig) {
   memset(pGIF, 0, sizeof(CGIF));
   pGIF->pFile = pFile;
   memcpy(&(pGIF->config), pConfig, sizeof(CGIF_Config));
-  // make a deep copy of GCT, if required.
+  // make a deep copy of global color tabele (GCT), if required.
   if((pConfig->attrFlags & CGIF_ATTR_NO_GLOBAL_TABLE) == 0) {
     pGIF->config.pGlobalPalette = malloc(pConfig->numGlobalPaletteEntries * 3);
     memcpy(pGIF->config.pGlobalPalette, pConfig->pGlobalPalette, pConfig->numGlobalPaletteEntries * 3);
@@ -255,7 +255,7 @@ static cgif_result flushFrame(CGIF* pGIF, CGIF_Frame* pCur, CGIF_Frame* pBef) {
   imageWidth     = pGIF->config.width;
   imageHeight    = pGIF->config.height;
   isFirstFrame   = (pBef == NULL) ? 1 : 0;
-  useLCT         = (pCur->config.attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? 1 : 0;
+  useLCT         = (pCur->config.attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) ? 1 : 0; // LCT stands for "local color table"
   hasAlpha       = ((pGIF->config.attrFlags & CGIF_ATTR_HAS_TRANSPARENCY) || (pCur->config.attrFlags & CGIF_FRAME_ATTR_HAS_ALPHA)) ? 1 : 0;
   hasSetTransp   = (pCur->config.attrFlags & CGIF_FRAME_ATTR_HAS_SET_TRANS) ? 1 : 0;
   disposalMethod = pCur->disposalMethod;

--- a/src/cgif_raw.c
+++ b/src/cgif_raw.c
@@ -424,7 +424,10 @@ CGIFRaw* cgif_raw_newgif(const CGIFRaw_Config* pConfig) {
   uint8_t  aHeader[SIZE_MAIN_HEADER];
   CGIFRaw* pGIF;
   int      rWrite;
-
+  // check for invalid GCT size
+  if(pConfig->sizeGCT > 256) {
+    return NULL; // invalid GCT size
+  }
   pGIF = malloc(sizeof(CGIFRaw));
   if(!pGIF) {
     return NULL;
@@ -475,6 +478,11 @@ cgif_result cgif_raw_addframe(CGIFRaw* pGIF, const CGIFRaw_FrameConfig* pConfig)
 
   if(pGIF->curResult != CGIF_OK && pGIF->curResult != CGIF_PENDING) {
     return pGIF->curResult; // return previous error
+  }
+  // check for invalid LCT size
+  if(pConfig->sizeLCT > 256) {
+    pGIF->curResult = CGIF_ERROR; // invalid LCT size
+    return pGIF->curResult;
   }
 
   rWrite = 0;

--- a/src/cgif_raw.c
+++ b/src/cgif_raw.c
@@ -471,7 +471,7 @@ cgif_result cgif_raw_addframe(CGIFRaw* pGIF, const CGIFRaw_FrameConfig* pConfig)
   uint8_t    aGraphicExt[SIZE_GRAPHIC_EXT];
   LZWResult  encResult;
   int        r, rWrite;
-  const int  useLCT = pConfig->sizeLCT;
+  const int  useLCT = pConfig->sizeLCT; // LCT stands for "local color table"
   uint16_t   numEffColors; // number of effective colors
   uint16_t   initDictLen;
   uint8_t    pow2LCT, initCodeLen;


### PR DESCRIPTION
Improved checking of user input in cgif for correctness. This includes:
- Check whether the color table(s) provided by the user have no more than 256 entries.
- Check if the user provided a color table at all (global or local).
- Bounds-check when looking up colors in the color table.