### PR TITLE
Run examples as tests

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,14 @@
+examples = [
+  'cgif_example',
+  'cgif_example_video',
+]
+
+foreach e : examples
+  ex_exe = executable(
+    'ex_' + e,
+    e + '.c',
+    dependencies : [libcgif_dep],
+    include_directories : ['../inc/'],
+  )
+  test(e, ex_exe)
+endforeach

--- a/meson.build
+++ b/meson.build
@@ -26,5 +26,6 @@ import('pkgconfig').generate(
 
 if get_option('tests') and not meson.is_cross_build()
   libcgif_dep = declare_dependency(link_with : lib)
+  subdir('examples')
   subdir('tests')
 endif


### PR DESCRIPTION
Run examples as tests, so we are always sure our examples compile & work as expected.