### PR TITLE
Fix potential crash if no color palette has been provided

### DIFF
--- a/src/cgif.c
+++ b/src/cgif.c
@@ -261,11 +261,6 @@ static cgif_result flushFrame(CGIF* pGIF, CGIF_Frame* pCur, CGIF_Frame* pBef) {
   hasSetTransp   = (pCur->config.attrFlags & CGIF_FRAME_ATTR_HAS_SET_TRANS) ? 1 : 0;
   disposalMethod = pCur->disposalMethod;
   transIndex     = pCur->transIndex;
-  // sanity check:
-  // at least one valid CT needed (global or local)
-  if(!useLCT && (pGIF->config.attrFlags & CGIF_ATTR_NO_GLOBAL_TABLE)) {
-    return CGIF_ERROR; // invalid config
-  }
   // deactivate impossible size optimizations
   //  => in case alpha channel is used
   // CGIF_FRAME_GEN_USE_TRANSPARENCY and CGIF_FRAME_GEN_USE_DIFF_WINDOW are not possible
@@ -388,6 +383,12 @@ int cgif_addframe(CGIF* pGIF, CGIF_FrameConfig* pConfig) {
   if((pGIF->config.attrFlags & CGIF_ATTR_HAS_TRANSPARENCY) && (pConfig->attrFlags & CGIF_FRAME_ATTR_HAS_ALPHA)) {
     pGIF->curResult = CGIF_ERROR;
     return pGIF->curResult;
+  }
+  // sanity check:
+  // at least one valid CT needed (global or local)
+  if(!(pConfig->attrFlags & CGIF_FRAME_ATTR_USE_LOCAL_TABLE) && (pGIF->config.attrFlags & CGIF_ATTR_NO_GLOBAL_TABLE)) {
+    pGIF->curResult = CGIF_ERROR;
+    return CGIF_ERROR; // invalid config
   }
 
   // if frame matches previous frame, drop it completely and sum the frame delay


### PR DESCRIPTION
Affects `main` only since b80b1250893c6fbaef20acab289837f174068245.
Potential crash (null-dereference) which occurred if no color palette was provided at all (neither global nor local).
Move sanity check from `flushFrame()` to `cgif_addframe()` to cover this edge case. We started to need the color palette in `cgif_addframe()` since #55.

Found by fuzzing cgif locally: https://github.com/google/oss-fuzz/pull/7321
```
==13==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7ff48bb7ee30 bp 0x7fff28933940 sp 0x7fff289330e8 T0)
==13==The signal is caused by a READ memory access.
==13==Hint: address points to the zero page.
SCARINESS: 10 (null-deref)
    #0 0x7ff48bb7ee30  (/lib/x86_64-linux-gnu/libc.so.6+0x184e30) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)
    #1 0x4c80ce in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) /src/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:881:16
    #2 0x4c844b in __interceptor_memcmp /src/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:892:10
    #3 0x56c128 in cmpPixel /src/cgif/build/../src/cgif.c:150:10
    #4 0x56c128 in cgif_addframe /src/cgif/build/../src/cgif.c:399:12
    #5 0x56a41b in processInput /src/cgif/fuzz/cgif_fuzzer.c:116:5
    #6 0x56a41b in LLVMFuzzerTestOneInput /src/cgif/fuzz/cgif_fuzzer.c:127:3
    #7 0x43ddc3 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #8 0x43d5aa in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:514:3
    #9 0x43ec79 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:757:19
    #10 0x43f945 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:895:5
    #11 0x42ecaf in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:912:6
    #12 0x458302 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #13 0x7ff48ba1e082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)
    #14 0x41f6ed in _start (/out/cgif_fuzzer+0x41f6ed)
```