### PR TITLE
Fix single frame alpha channel

### DIFF
--- a/fuzz/seeds.md5
+++ b/fuzz/seeds.md5
@@ -11,7 +11,11 @@ fdae5756b1b807a17e53981ed8426265  duplicate_frames.seed
 f715df62ce010400b45c8390f7a0d7d2  earlyclose.seed
 bd190d8bf4593e52a12c676883344ece  eindex_anim.seed
 0ce95a93c456402d2ebbf45a5cf97f5c  eindex.seed
+5b1be0065462dd6eef37f12c2f925726  enopalette.seed
 464c002f693d92ceb6d563a3d311ab8c  ewrite.seed
+15f002ddcbb97d4925ca1f0b487846ac  ezeroheight.seed
+7a28c753e37ecd51bbda7373b1ce6957  ezerowidthheight.seed
+f05b915115a7415612f6f49ca584a16d  ezerowidth.seed
 72016c39357f0f537ec1f9781aa5c113  global_plus_local_table.seed
 af5b1905892c651b12a54249b1cc223e  global_plus_local_table_with_optim.seed
 f995725c6e8ef70707f0a7c21fdbe2fd  has_transparency_2.seed
@@ -30,7 +34,9 @@ af137262379b55c94306fd2f8ad1b89d  more_than_256_colors.seed
 d1dc83612bb62980c4c7a63bd0802cc6  overlap_everything_only_trans.seed
 207b5d6928ded8bdea9b3509c6d44c8b  overlap_everything.seed
 9ebff14069677230197ceeea66910f50  overlap_some_rows.seed
+9d2b6c0e5c7fb108f026064996313307  single_frame_alpha.seed
 b77b115cb1876f1bffff47c93c574b1b  stripe_pattern_interlaced.seed
+7c2a160987b6a0ec807d757004cfdddd  switchpattern.seed
 261fb31b5dce05c027ff88afaa511ceb  trans_inc_initdict.seed
 7ba7d70015744018f185fe46df7b3c3c  user_trans.seed
 464c002f693d92ceb6d563a3d311ab8c  write_fn.seed

--- a/src/cgif_raw.c
+++ b/src/cgif_raw.c
@@ -513,6 +513,7 @@ cgif_result cgif_raw_addframe(CGIFRaw* pGIF, const CGIFRaw_FrameConfig* pConfig)
   // calculate initial code length and initial dict length
   initCodeLen = calcInitCodeLen(numEffColors);
   initDictLen = 1uL << (initCodeLen - 1);
+  const uint8_t initialCodeSize = initCodeLen - 1;
 
   const uint16_t frameWidthLE  = hU16toLE(pConfig->width);
   const uint16_t frameHeightLE = hU16toLE(pConfig->height);
@@ -565,7 +566,6 @@ cgif_result cgif_raw_addframe(CGIFRaw* pGIF, const CGIFRaw_FrameConfig* pConfig)
     return r;
   }
 
-  const uint8_t initialCodeSize = initCodeLen - 1;
   // check whether the Graphic Control Extension is required or not:
   // It's required for animations and frames with transparency.
   int needsGraphicCtrlExt = (pGIF->config.attrFlags & CGIF_RAW_ATTR_IS_ANIMATED) | (pConfig->attrFlags & CGIF_RAW_FRAME_ATTR_HAS_TRANS);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -38,6 +38,7 @@ tests = [
   { 'name' : 'overlap_everything',                 'seed_should_fail' : false},
   { 'name' : 'overlap_everything_only_trans',      'seed_should_fail' : false},
   { 'name' : 'overlap_some_rows',                  'seed_should_fail' : false},
+  { 'name' : 'single_frame_alpha',                 'seed_should_fail' : false},
   { 'name' : 'stripe_pattern_interlaced',          'seed_should_fail' : false},
   { 'name' : 'switchpattern',                      'seed_should_fail' : false},
   { 'name' : 'trans_inc_initdict',                 'seed_should_fail' : false},

--- a/tests/single_frame_alpha.c
+++ b/tests/single_frame_alpha.c
@@ -1,0 +1,54 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "cgif.h"
+
+#define WIDTH 1
+#define HEIGHT 1
+
+int main(void) {
+  CGIF*          pGIF;
+  CGIF_Config     gConfig;
+  CGIF_FrameConfig   fConfig;
+  uint8_t*      pImageData;
+  uint8_t       aPalette[] = {
+    0xFF, 0xFF, 0xFF, // white
+  };
+  cgif_result r;
+
+  memset(&gConfig, 0, sizeof(CGIF_Config));
+  memset(&fConfig, 0, sizeof(CGIF_FrameConfig));
+  gConfig.width                   = WIDTH;
+  gConfig.height                  = HEIGHT;
+  gConfig.pGlobalPalette          = aPalette;
+  gConfig.numGlobalPaletteEntries = 1;
+  gConfig.path                    = "single_frame_alpha.gif";
+  //
+  // create new GIF
+  pGIF = cgif_newgif(&gConfig);
+  if(pGIF == NULL) {
+    fputs("failed to create new GIF via cgif_newgif()\n", stderr);
+    return 1;
+  }
+  //
+  // add frames to GIF
+  pImageData = malloc(WIDTH * HEIGHT);
+  memset(pImageData, 1, WIDTH * HEIGHT); // set all transparent
+  fConfig.pImageData = pImageData;
+  fConfig.attrFlags = CGIF_FRAME_ATTR_HAS_ALPHA;
+  fConfig.transIndex = 1;
+  cgif_addframe(pGIF, &fConfig);
+  free(pImageData);
+  //
+  // write GIF to file
+  r = cgif_close(pGIF);
+
+  // check for errors
+  if(r != CGIF_OK) {
+    fprintf(stderr, "failed to create GIF. error code: %d\n", r);
+    return 2;
+  }
+  return 0;
+}

--- a/tests/tests.md5
+++ b/tests/tests.md5
@@ -8,6 +8,8 @@ b30bd5a37fbaf2eca0ed00fd0822627a  animated_stripe_pattern_2.gif
 a8c2e6153396de90eaa1947178b1e383  animated_stripe_pattern.gif
 7a86f68119152391ecb1f2cc68de00ef  animated_stripes_horizontal.gif
 03e09ed425aa710f089f09ce7b080c76  duplicate_frames.gif
+f362f8d8f18fda56249ba43f2a447df8  example_cgif.gif
+cdd7b0e7d2ec0934ff57f0cefe329d77  example_video_cgif.gif
 0f099cb93337738ee8a91fe7b317d696  global_plus_local_table.gif
 11b1703658c920b6f86d32827291dde4  global_plus_local_table_with_optim.gif
 3eda7f993b36270db09929a289a5a106  has_transparency_2.gif
@@ -27,6 +29,7 @@ a7c04cb7b6d19a16023497da03384408  only_local_table.gif
 013513307101f1d6b80164cdb3318c1c  overlap_everything.gif
 5a72df08de28f6a72dfed41c635db9e9  overlap_everything_only_trans.gif
 e9e789738541e15028dfe2abdbc67314  overlap_some_rows.gif
+f00a57c6e1727d1d8392c97cb994bb48  single_frame_alpha.gif
 aa31b2280914bb30b9b9525f8e0b87d8  stripe_pattern_interlaced.gif
 3ecf5e35fe4b5b319931985f1524ba62  switchpattern.gif
 41b1b51c1aebb0ec72b44d0d2a395d58  trans_inc_initdict.gif


### PR DESCRIPTION
The Graphic Control Extension is not just required for animations, but for single frame alpha channel images as well.
Make sure we write the Graphic Control Extension if transparency is present.

**Current main (216d71bfd70c6ccfa82081e6e7eb129aeb9d44fa):**
```
$ giftext build/single_frame_alpha.gif 

build/single_frame_alpha.gif:

	Screen Size - Width = 1, Height = 1.
	ColorResolution = 1, BitsPerPixel = 1, BackGround = 0, Aspect = 0.
	Has Global Color Map.


Image #1:

	Image Size - Left = 0, Top = 0, Width = 1, Height = 1.
	Image is Non Interlaced.
	No Image Color Map.

GIF file terminated normally.
```

**[fix-single-frame-alpha-channel](https://github.com/dloebl/cgif/pull/60):**
```
$ giftext build/single_frame_alpha.gif 

build/single_frame_alpha.gif:

	Screen Size - Width = 1, Height = 1.
	ColorResolution = 1, BitsPerPixel = 1, BackGround = 0, Aspect = 0.
	Has Global Color Map.


GIF89 graphics control (Ext Code = 249 [ ]):
	Disposal Mode: 1
	User Input Flag: 0
	Transparency on: yes
	DelayTime: 0
	Transparent Index: 1

Image #1:

	Image Size - Left = 0, Top = 0, Width = 1, Height = 1.
	Image is Non Interlaced.
	No Image Color Map.

GIF file terminated normally.
```

**ToDo:**
- [ ] Backport to v0.3.0 and release v0.3.1