### PR TITLE
Fix oss-fuzz build

### DIFF
--- a/tests/noise256.c
+++ b/tests/noise256.c
@@ -10,6 +10,8 @@
 
 static uint64_t seed;
 
+// unsigned integer overflow expected
+__attribute__((no_sanitize("integer")))
 int psdrand(void) {
   // simple pseudo random function from musl libc
   seed = 6364136223846793005ULL * seed + 1;

--- a/tests/noise6.c
+++ b/tests/noise6.c
@@ -10,6 +10,8 @@
 
 static uint64_t seed;
 
+// unsigned integer overflow expected
+__attribute__((no_sanitize("integer")))
 int psdrand(void) {
   // simple pseudo random function from musl libc
   seed = 6364136223846793005ULL * seed + 1;

--- a/tests/noise6_interlaced.c
+++ b/tests/noise6_interlaced.c
@@ -10,6 +10,8 @@
 
 static uint64_t seed;
 
+// unsigned integer overflow expected
+__attribute__((no_sanitize("integer")))
 int psdrand(void) {
   // simple pseudo random function from musl libc
   seed = 6364136223846793005ULL * seed + 1;


### PR DESCRIPTION
Ignore expected unsigned integer overflow in some tests.
For reference: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67421