### PR TITLE
set minimum meson version to v0.56 and fix warnings

### DIFF
--- a/fuzz/meson.build
+++ b/fuzz/meson.build
@@ -3,14 +3,14 @@
 zip = find_program('zip', required : false)
 foreach t : tests
   name = t.get('name')
-  src = [join_paths(meson.source_root(), 'tests', name + '.c'), 'cgif_create_fuzz_seed.c']
+  src = [join_paths(meson.project_source_root(), 'tests', name + '.c'), 'cgif_create_fuzz_seed.c']
   cflags = ['-D', 'CGIF_OUTPATH="' + name + '.seed' + '"']
   exe = executable(name + '_genseed', sources : src, c_args : cflags, include_directories : ['../inc'])
-  test('generate ' + name + '.seed', exe, workdir : join_paths(meson.build_root(), 'fuzz'), priority : -2, should_fail : t.get('seed_should_fail'))
+  test('generate ' + name + '.seed', exe, workdir : join_paths(meson.project_build_root(), 'fuzz'), priority : -2, should_fail : t.get('seed_should_fail'))
 endforeach
 # get the ordering right:
 # sha256sum check on fuzz seed corpus should be run once all of the above tests are done.
-test('check fuzz seed checksums', sha256sumc, args : [join_paths(meson.source_root(), 'fuzz/seeds.sha256')], workdir : join_paths(meson.build_root(), 'fuzz'), priority : -3, is_parallel : false)
+test('check fuzz seed checksums', sha256sumc, args : [join_paths(meson.project_source_root(), 'fuzz/seeds.sha256')], workdir : join_paths(meson.project_build_root(), 'fuzz'), priority : -3, is_parallel : false)
 
 src = ['cgif_fuzzer_standalone.c', 'cgif_fuzzer.c']
 exe_fuzzer = executable(
@@ -30,8 +30,8 @@ exe_file_fuzzer = executable(
 # test seed corpus with standalone fuzzer and standalone file fuzzer
 foreach t : tests
   seedpath = t.get('name') + '.seed'
-  test('run cgif_fuzzer_standalone ' + seedpath, exe_fuzzer, args : seedpath, workdir : join_paths(meson.build_root(), 'fuzz'), priority : -4)
-  test('run cgif_file_fuzzer_standalone ' + seedpath, exe_file_fuzzer, args : seedpath, workdir : join_paths(meson.build_root(), 'fuzz'), priority : -4)
+  test('run cgif_fuzzer_standalone ' + seedpath, exe_fuzzer, args : seedpath, workdir : join_paths(meson.project_build_root(), 'fuzz'), priority : -4)
+  test('run cgif_file_fuzzer_standalone ' + seedpath, exe_file_fuzzer, args : seedpath, workdir : join_paths(meson.project_build_root(), 'fuzz'), priority : -4)
 endforeach
 
 # generate seed corpus zip archive, if possible
@@ -40,6 +40,6 @@ if zip.found()
   foreach t : tests
     seeds += t.get('name') + '.seed'
   endforeach
-  test('create fuzzer seed corpus zip archive', zip, args : ['cgif_fuzzer_seed_corpus.zip', seeds], workdir : join_paths(meson.build_root(), 'fuzz'), priority : -4)
-  test('create file fuzzer seed corpus zip archive', zip, args : ['cgif_file_fuzzer_seed_corpus.zip', seeds], workdir : join_paths(meson.build_root(), 'fuzz'), priority : -4)
+  test('create fuzzer seed corpus zip archive', zip, args : ['cgif_fuzzer_seed_corpus.zip', seeds], workdir : join_paths(meson.project_build_root(), 'fuzz'), priority : -4)
+  test('create file fuzzer seed corpus zip archive', zip, args : ['cgif_file_fuzzer_seed_corpus.zip', seeds], workdir : join_paths(meson.project_build_root(), 'fuzz'), priority : -4)
 endif

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project(
   'libcgif',
   'c',
   version : '0.5.0',
+  meson_version: '>=0.56',
   license : 'MIT',
   default_options : ['c_std=c99'],
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -63,4 +63,4 @@ endforeach
 sha256sumc = find_program('scripts/sha256sum.py')
 # get the ordering right:
 # md5sum check on output GIFs should be run once all of the above tests are done.
-test('check test checksums', sha256sumc, args : [join_paths(meson.source_root(), 'tests/tests.sha256')], workdir : meson.build_root(), priority : -1, is_parallel : false)
+test('check test checksums', sha256sumc, args : [join_paths(meson.project_source_root(), 'tests/tests.sha256')], workdir : meson.project_build_root(), priority : -1, is_parallel : false)


### PR DESCRIPTION
Set the minimum meson version of the project to v0.56 and fix all meson warnings by removing all use of deprecated functions (`meson.source_root()` and `meson.build_root()`).
For reference: https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonsource_root and https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonbuild_root
