### PR TITLE
fix(cgif_rgb): use temp pointers for realloc

### DIFF
--- a/src/cgif_rgb.c
+++ b/src/cgif_rgb.c
@@ -154,12 +154,22 @@ static void free_col_hash_table(colHashTable* colhash){
 /* increase the size of the color hash table */
 static void resize_col_hash_table(colHashTable* colhash){
   uint32_t tableSizeNew;
-  tableSizeNew  = getNextPrimePower2(colhash->tableSize); // increase table size to the next prime number above the next power of two
-  colhash->pPalette      = realloc(colhash->pPalette, 3 * tableSizeNew);
-  colhash->colIdx        = realloc(colhash->colIdx, sizeof(uint32_t) * tableSizeNew);
-  uint8_t* hashTable_new = malloc(3 * tableSizeNew);
-  uint8_t* indexUsed_new = malloc(tableSizeNew);
-  uint32_t* frequ_new = malloc(sizeof(uint32_t) * tableSizeNew);
+  tableSizeNew = getNextPrimePower2(colhash->tableSize); // increase table size to the next prime number above the next power of two
+  // use temporary pointers so the original is not lost if realloc fails
+  uint8_t*  pPalette_new  = realloc(colhash->pPalette, 3 * tableSizeNew);
+  uint32_t* colIdx_new    = realloc(colhash->colIdx, sizeof(uint32_t) * tableSizeNew);
+  uint8_t*  hashTable_new = malloc(3 * tableSizeNew);
+  uint8_t*  indexUsed_new = malloc(tableSizeNew);
+  uint32_t* frequ_new     = malloc(sizeof(uint32_t) * tableSizeNew);
+  if(pPalette_new == NULL || colIdx_new == NULL || hashTable_new == NULL ||
+     indexUsed_new == NULL || frequ_new == NULL) {
+    free(hashTable_new);
+    free(indexUsed_new);
+    free(frequ_new);
+    return; // leave colhash unchanged; original pointers still valid
+  }
+  colhash->pPalette = pPalette_new;
+  colhash->colIdx   = colIdx_new;
   memset(indexUsed_new, 0, tableSizeNew);
   colhash->cnt = 0;
   for(uint32_t j = 0; j < colhash->tableSize; ++j) { // TBD (no improvement when tested): easier to loop over pPalette and also leave pPalette in place?, if indexUsed is also unnecessary then


### PR DESCRIPTION
fix(cgif_rgb): use temp pointers for realloc in resize_col_hash_table

Storing the realloc() result directly into colhash->pPalette and
colhash->colIdx means that on failure the original pointer is lost
(CWE-401 memory leak) and the struct fields become NULL, causing a
NULL pointer dereference on the next access (CWE-476).

Fix by capturing both realloc results in temporary pointers, checking
all five allocations together, freeing the three new buffers and
returning early on any failure, then committing the new pointers to
the struct only when all allocations succeed.

Fixes: CWE-476 (NULL Pointer Dereference), CWE-401 (Memory Leak)