### PR TITLE
fix potential integer overflow in raw API

### DIFF
--- a/src/cgif_raw.c
+++ b/src/cgif_raw.c
@@ -330,7 +330,7 @@ static int LZW_GenerateStream(LZWResult* pResult, const uint32_t numPixel, const
   // where N = max dictionary resets = numPixel / (MAX_DICT_LEN - initDictLen - 2)
   entriesPerCycle = MAX_DICT_LEN - initDictLen - 2; // maximum added number of dictionary entries per cycle: -2 to account for start and end code
   maxResets = numPixel / entriesPerCycle;
-  pContext->pLZWData   = malloc(sizeof(uint16_t) * (numPixel + 2 + maxResets));
+  pContext->pLZWData   = malloc(sizeof(uint16_t) * ((size_t)numPixel + 2 + maxResets));
   if(pContext->pLZWData == NULL) {
     r = CGIF_EALLOC;
     goto LZWGENERATE_Cleanup;


### PR DESCRIPTION
Regression introduced with [v0.5.1](https://github.com/dloebl/cgif/releases/tag/v0.5.1)/#84.
There is potentially a small integer overflow in the LZW encoding logic affecting _very_ large GIFs (65.535 x 65.535):
```c
pContext->pLZWData = malloc(sizeof(uint16_t) * (numPixel + 2 + maxResets));
```

`u32:numPixel` is at max `4.294.836.225`: `(2^16-1)^2`
`u32:maxResets` is at max `1.119.029`: `4.294.836.225`/`3838`

And now `4.294.836.225` + `1.119.029` + `2` is `4.295.955.256` - which is above the maximum value a 32-bit unsigned integer can hold `4.294.967.295` (`2^32-1`).

The fix is to simply cast to `size_t` before the calculation:
```c
pContext->pLZWData = malloc(sizeof(uint16_t) * ((size_t)numPixel + 2 + maxResets));
```

This is only affecting very large GIFs (at the very end of the dimension limit), with small color palettes.
In a follow-up, we can also make this handling more gracefully on 32-bit systems - but for now it's fine.